### PR TITLE
Added support for running official HF baseline FSDP-QLoRA benchmark

### DIFF
--- a/plugins/accelerated-peft/configs/bnb.yaml
+++ b/plugins/accelerated-peft/configs/bnb.yaml
@@ -14,3 +14,7 @@ peft:
     # bitsandbytes:
     bitsandbytes:
       quant_type: nf4 
+
+      # If True, then no get_peft_model and prepare_model_for_kbit_training
+      # will be called. 
+      no_peft_model: False

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -96,6 +96,9 @@ class BNBAccelerationPlugin(AccelerationPlugin):
         self._quant_type = self._check_config_and_maybe_check_values(
             key="peft.quantization.bitsandbytes.quant_type", values=["fp4", "nf4"]
         )
+        self.no_peft_model = self._check_config_and_maybe_check_values(
+            key="peft.quantization.bitsandbytes.no_peft_model", values=[True, False]
+        )
 
     def model_loader(self, model_name: str, **kwargs):
 
@@ -147,7 +150,8 @@ class BNBAccelerationPlugin(AccelerationPlugin):
 
     @property
     def requires_agumentation(self):
-        return True
+        # requires augmentation if no_peft_model is False
+        return not self.no_peft_model
 
     def augmentation(
         self,

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -124,6 +124,16 @@ class BNBAccelerationPlugin(AccelerationPlugin):
                 "If running in FSDP, this is probably because accelerate is not used. "
                 "This will most probably result in error."
             )
+        elif (
+            world_size == 1
+            and self._no_peft_model == True
+        ):
+            warnings.warn(
+                """Running on single device and setting plugin config `no_peft_model` as `True`
+                PEFT preparation will be managed by SFTTrainer and will cause a slowdown in training speed 
+                due to extraneous dtype casting when SFTTrainer prepares the model using
+                https://github.com/huggingface/trl/blob/e90e8d91d2265e484f229c45a5eb8982f94a2936/trl/trainer/sft_trainer.py#L210"""
+            )            
 
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -96,7 +96,7 @@ class BNBAccelerationPlugin(AccelerationPlugin):
         self._quant_type = self._check_config_and_maybe_check_values(
             key="peft.quantization.bitsandbytes.quant_type", values=["fp4", "nf4"]
         )
-        self.no_peft_model = self._check_config_and_maybe_check_values(
+        self._no_peft_model = self._check_config_and_maybe_check_values(
             key="peft.quantization.bitsandbytes.no_peft_model", values=[True, False]
         )
 
@@ -150,8 +150,8 @@ class BNBAccelerationPlugin(AccelerationPlugin):
 
     @property
     def requires_agumentation(self):
-        # requires augmentation if no_peft_model is False
-        return not self.no_peft_model
+        # will skip the augmentation if _no_peft_model == True
+        return not self._no_peft_model
 
     def augmentation(
         self,

--- a/plugins/accelerated-peft/tests/test_peft_plugins.py
+++ b/plugins/accelerated-peft/tests/test_peft_plugins.py
@@ -122,6 +122,20 @@ def test_configure_bnb_plugin():
             assert framework.requires_agumentation
             assert len(framework.get_callbacks_and_ready_for_train()) == 0
 
+    # test no_peft_model is true skips plugin.augmentation
+    for key, correct_value in [
+        ("peft.quantization.bitsandbytes.no_peft_model", True),
+        ("peft.quantization.bitsandbytes.no_peft_model", False),
+    ]:
+        with instantiate_framework(
+            update_configuration_contents(
+                read_configuration(CONFIG_PATH_BNB), key, correct_value
+            ),
+            require_packages_check=False,
+        ):
+            # check flags and callbacks
+            assert (not correct_value)==framework.requires_agumentation
+
     # attempt to activate plugin with configuration pointing to wrong path
     # - raise with message that no plugins can be configured
     with pytest.raises(ValueError) as e:

--- a/sample-configurations/CONTENTS.yaml
+++ b/sample-configurations/CONTENTS.yaml
@@ -15,3 +15,8 @@ framework_configs:
       plugins:
         - accelerated-peft
       filename: accelerated-peft-bnb-nf4-sample-configuration.yaml
+
+    - shortname: baseline-peft-bnb
+      plugins:
+        - accelerated-peft
+      filename: baseline-peft-bnb-nf4-sample-configuration.yaml

--- a/sample-configurations/baseline-peft-bnb-nf4-sample-configuration.yaml
+++ b/sample-configurations/baseline-peft-bnb-nf4-sample-configuration.yaml
@@ -21,4 +21,4 @@ plugins:
 
         # If True, then no get_peft_model and prepare_model_for_kbit_training
         # will be called. 
-        no_peft_model: false
+        no_peft_model: true

--- a/scripts/benchmarks/scenarios.yaml
+++ b/scripts/benchmarks/scenarios.yaml
@@ -32,6 +32,23 @@ scenarios:
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
                 - 'NousResearch/Llama-2-70b-hf'
 
+    -   name: baseline-peft-bnb
+        framework_config: 
+            - baseline-peft-bnb
+        arguments:
+            fp16: True
+            learning_rate: 2e-4
+            torch_dtype: float16
+            peft_method: lora
+            r: 16
+            lora_alpha: 16
+            lora_dropout: 0.0
+            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+            model_name_or_path: 
+                - 'mistralai/Mistral-7B-v0.1'
+                - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
+                - 'NousResearch/Llama-2-70b-hf'
+
     -   name: accelerated-peft-bnb
         framework_config: 
             - accelerated-peft-bnb

--- a/scripts/generate_sample_configurations.py
+++ b/scripts/generate_sample_configurations.py
@@ -141,12 +141,20 @@ def read_configuration(path: str) -> Dict:
 # specified key path, with the value.
 KEY_AUTO_GPTQ = "auto_gptq"
 KEY_BNB_NF4 = "bnb-nf4"
+KEY_BNB_NF4_BASELINE = "baseline-bnb-nf4"
 
 CONFIGURATIONS = {
     KEY_AUTO_GPTQ: "plugins/accelerated-peft/configs/autogptq.yaml",
     KEY_BNB_NF4: (
         "plugins/accelerated-peft/configs/bnb.yaml",
         [("peft.quantization.bitsandbytes.quant_type", "nf4")],
+    ),
+    KEY_BNB_NF4_BASELINE: (
+        "plugins/accelerated-peft/configs/bnb.yaml",
+        [
+            ("peft.quantization.bitsandbytes.quant_type", "nf4"), 
+            ("peft.quantization.bitsandbytes.no_peft_model", True), 
+        ],
     ),
 }
 
@@ -158,6 +166,7 @@ CONFIGURATIONS = {
 COMBINATIONS = [
     ("accelerated-peft-autogptq", (KEY_AUTO_GPTQ,)),
     ("accelerated-peft-bnb-nf4", (KEY_BNB_NF4,)),
+    ("baseline-peft-bnb-nf4", (KEY_BNB_NF4_BASELINE,)),
 ]
 
 


### PR DESCRIPTION
This PR addresses issue #10 by adding support for a FSDP-compatible HF QLoRA baseline to the our benchmarks. 

### Feature
This will allow users to specify a `no_peft_model` field in the plugin config `bnb.yaml`. Specifying this field will bypass the `plugin.augmentation` function and allow SFTTrainer to manage the PEFT preparation of the model instead. 

#### NOTE:
- While the open-source approach to FSDP-compatible QLoRA removes the extraneous dtype casting in `prepare_model_for_kbit_training`, it only does so when the model is sharded. When on single device, it continues to use `prepare_model_for_kbit_training` and users will continue to experience a slowdown due to the extraneous casting.