### PR TITLE
Workaround Low-Mem-Mode Patch for GPTQ-LoRA

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -24,6 +24,36 @@ from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
 import torch
 
 
+def make_sure_no_tensor_in_meta_device(
+    model,
+    use_triton: bool,
+    desc_act: bool,
+    group_size: int,
+    bits: int,
+    disable_exllama: bool,
+    disable_exllamav2: bool,
+    use_marlin: bool = False,
+    use_tritonv2: bool = False,
+):
+    from auto_gptq.utils.import_utils import dynamically_import_QuantLinear  #pylint: disable=import-outside-toplevel,import-error
+    QuantLinear = dynamically_import_QuantLinear(
+        use_triton,
+        desc_act,
+        group_size,
+        bits=bits,
+        disable_exllama=disable_exllama,
+        disable_exllamav2=disable_exllamav2,
+        use_marlin=use_marlin,
+        use_tritonv2=use_tritonv2
+        )
+    for n, m in model.named_modules():
+        bias = getattr(m, "bias", None)
+        if bias:
+            if isinstance(m, QuantLinear) and bias.device == torch.device("meta"):
+                m.register_buffer(
+                    "bias", torch.zeros((m.outfeatures), dtype=torch.float16, device="cpu")
+                    )
+
 def replace_module_peft(self, parent_module, child_name, new_module, old_module):
 
     # replace the lora linear

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -16,13 +16,35 @@
 # https://spdx.dev/learn/handling-license-info/
 
 # Standard
-from typing import Callable, List
+from typing import Callable, List, Any
+import importlib
 
 # Third Party
 from peft import LoraConfig
 from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
 import torch
 
+def patch_target_module(
+    to_patch: str,
+    replace_with: Any,
+    target_module: str = None,
+):
+    to_patch = to_patch.split('.')
+    assert len(to_patch) > 1, "must have an object to patch"
+
+    to_patch, obj_name_to_patch = to_patch[:-1], to_patch[-1]
+    to_patch = ".".join(to_patch)
+    source = importlib.import_module(to_patch)
+    original_obj = getattr(source, obj_name_to_patch)
+    setattr(source, obj_name_to_patch, replace_with)
+
+    if target_module is not None:
+        # reload and this should get the patched object
+        target_module = importlib.import_module(target_module)
+        importlib.reload(target_module)
+
+        # replace it
+        setattr(source, obj_name_to_patch, original_obj)
 
 def make_sure_no_tensor_in_meta_device(
     model,

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -25,7 +25,7 @@ from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
 import torch
 
 
-# This function will be replaced after merging
+# This function may be moved after merging
 # https://github.com/foundation-model-stack/fms-acceleration/pull/25
 def _patch_target_module(
     to_patch: str,
@@ -62,6 +62,7 @@ def make_sure_no_tensor_in_meta_device(
     use_tritonv2: bool = False,
 ):
     # Third Party
+    # guarded import
     from auto_gptq.utils.import_utils import (  # pylint: disable=import-outside-toplevel,import-error
         dynamically_import_QuantLinear,
     )

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -100,6 +100,8 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         )
         AutoModelForCausalLM.from_config = _from_config  # patch
 
+        # this is a HF method that checks if the low_cpu_mem mode is enabled
+        # via HF accelerate
         if is_fsdp_enabled():
             # Local
             from .autogptq_utils import (  # pylint: disable=import-outside-toplevel

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -51,13 +51,8 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
     def model_loader(self, model_name: str, **kwargs):
         # guarded imports
         # Third Party
-        from auto_gptq import (  # pylint: disable=import-outside-toplevel,import-error
-            AutoGPTQForCausalLM,
-            BaseQuantizeConfig,
-        )
-        from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import (  # pylint: disable=import-outside-toplevel,import-error
-            QuantLinear,
-        )
+        from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig #pylint: disable=import-outside-toplevel,import-error
+        from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear #pylint: disable=import-outside-toplevel,import-error
 
         # Local
         from .autogptq_utils import (  # pylint: disable=import-outside-toplevel

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -221,14 +221,8 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
     ):
         # guarded imports
         # Third Party
-        from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import (  # pylint: disable=import-outside-toplevel,import-error
-            QuantLinear,
-        )
-        from auto_gptq.utils.peft_utils import (  # pylint: disable=import-outside-toplevel,import-error
-            GPTQLoraModel,
-            get_gptq_peft_model,
-        )
-
+        from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear #pylint: disable=import-outside-toplevel,import-error
+        from auto_gptq.utils.peft_utils import GPTQLoraModel, get_gptq_peft_model #pylint: disable=import-outside-toplevel,import-error
         # Local
         from .autogptq_utils import (  # pylint: disable=import-outside-toplevel
             create_new_module_peft,

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -164,6 +164,7 @@ We currently compute the memory values in the report by taking the largest of su
 For allocated memory value
 ```
 max([
+  stage0_mem,
   stage0_mem + stage1_allocated_delta, 
   stage0_mem + stage1_allocated_delta + stage2_allocated_delta,
   ...
@@ -173,13 +174,13 @@ max([
 For peak memory value
 ```
 max([
+  stage0_mem,
   stage0_mem + stage1_allocated_delta + stage1_peaked_delta, 
   stage0_mem + stage1_allocated_delta + stage2_allocated_delta + stage2_peaked_delta,
   ...
 ])
 ```
 
-Notice that we do not include `stage0_mem` alone when computing the max value. This is to avoid misleading comparisons between GPTQ-LoRA and others. GPTQ-LoRA + FSDP currently does not support low-memory mode as mentioned [here](https://github.com/foundation-model-stack/fms-acceleration/issues/18). The `stage0_mem` value of GPTQ-LoRA + FSDP will reflect a larger than expected value as it is loaded fully before the trainer is initialized and then subsequently will be sharded internally in `trainer.prepare`. This might cause some misleading comparisons when other variants are loaded in low-memory mode and have smaller `stage0_mem` memory consumption than GPTQ-LoRA + FSDP. Once low-memory mode is supported for GPTQ-LoRA, we will include `stage0_mem` back inside the max computation
 
 We compare memory values between Nvidia-SMI and Torch in this PR - [Memory Benchmarking](https://github.com/foundation-model-stack/fms-acceleration/pull/14).
 

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -112,8 +112,8 @@ def extract_gpu_memory_metrics(output_metrics) -> Tuple[float]:
         return 0, 0
 
     trainer_stage_order = [
-        (HF_TRAINER_LOG_GPU_STAGE_BEFORE_INIT, False),
-        (HF_TRAINER_LOG_GPU_STAGE_INIT, False),
+        (HF_TRAINER_LOG_GPU_STAGE_BEFORE_INIT, True),
+        (HF_TRAINER_LOG_GPU_STAGE_INIT, True),
         (HF_TRAINER_LOG_GPU_STAGE_TRAIN, True),
     ]
     alloc_running_sum = 0


### PR DESCRIPTION
# Description
This PR addresses #18 with the following contributions

- Introduce  patch on AutoGPTQ's `make_sure_no_tensor_in_meta_device` to avoid raising an error when model has no bias in low memory mode
- Workaround to configuring `device_map` to `cpu` when loading checkpoints to avoid gpu memory consumption before trainer initialization.
_Note: This approach diverts consumption to cpu mem which could still bottleneck, a better approach could be to load it to `meta` device. QLoRA currently loads quantized models to `cpu` in low memory mode as well. See [here.](https://github.com/huggingface/transformers/pull/25107#issuecomment-2134833262)_

TODO:
- Actual device mapping to `meta` device

# Tests
## Reproduction command
```
accelerate launch --config_file scripts/benchmarks/accelerate.yaml --num_processes=2 --main_process_port=29500 -m tuning.sft_trainer --model_name_or_path TheBloke/Llama-2-70B-GPTQ --acceleration_framework_config_file /data/aaron/experimental/test3/scripts/benchmarks/../../sample-configurations/accelerated-peft-autogptq-sample-configuration.yaml --packing True --max_seq_len 4096 --learning_rate 2e-4 --fp16 True --torch_dtype float16 --peft_method lora --r 16 --lora_alpha 16 --lora_dropout 0.0 --target_modules q_proj k_proj v_proj o_proj --use_flash_attn True --response_template '\n### Response:' --dataset_text_field 'output' --include_tokens_per_second True --num_train_epochs 1 --gradient_accumulation_steps 1 --gradient_checkpointing True --evaluation_strategy no --save_strategy no --weight_decay 0.01 --warmup_steps 10 --adam_epsilon 1e-4 --lr_scheduler_type linear --logging_strategy steps --logging_steps 10 --max_steps 10 --training_data_path /data/aaron/experimental/test3/benchmark_outputs_final/data/cache.json --per_device_train_batch_size 2 --output_dir benchmark_outputs/exp_57/hf --skip_memory_metrics False
```
## Comparison
### Before Fix: 
Memory Explosion in GPTQ-LoRA without low memory mode observed in the memory metrics, Nvidia (78.80 GiB) and Torch (36.1 GiB) compared to QLoRA with low memory mode enabled.
| model<br>name | framework<br>config |    num<br>gpus    | per device<br>train<br>batch<br>size | nvidia<br>mem reserved<br>(GiB) | peak torch<br>mem alloc<br>(GiB)<br> | torch<br>mem alloc<br>(GiB)<br> | throughput (toks/sec) |
| --------------------------- | --------------------- | ---------------------- | ------------------ | ------------------- | ----------------------------- | ------------------------ | ----------------- |
| NousResearch/Llama-2-70b-hf | accelerated-peft-bnb      | 2 | 2 | 51.40 | 46.52 | 19.17 | 417 |
| TheBloke/Llama-2-70B-GPTQ   | accelerated-peft-autogptq | 2 | 2 | 78.80 | *45.40* | *36.14* | 429 |

### After Fix: 
With Low Memory mode enabled, GPTQ-LoRA now has lower memory consumption  Nvidia (49.4 GiB) and Torch (18.1 GiB) and is comparable with QLoRA
| model<br>name | framework<br>config |    num<br>gpus    | per device<br>train<br>batch<br>size | nvidia<br>mem reserved<br>(GiB) | peak torch<br>mem alloc<br>(GiB)<br> | torch<br>mem alloc<br>(GiB)<br> | throughput (toks/sec) |
| --------------------------- | --------------------- | ---------------------- | ------------------ | ------------------- | ----------------------------- | ------------------------ | ----------------- |
| NousResearch/Llama-2-70b-hf | accelerated-peft-bnb      | 2 | 2 | 51.40 | 46.52 | 19.17 | 414 |
| TheBloke/Llama-2-70B-GPTQ   | accelerated-peft-autogptq | 2 | 2 | 49.44 | **44.87** | **18.13** | 428 |
