### PR TITLE
Allow Benchmarks to be run with configuration pointed to in YAML env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,35 @@ Plugin | Description | Depends | License | Status
 
 Below we demonstrate how to accelerate your tuning experience with [tuning/sft_trainer.py](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/tuning/sft_trainer.py) from `fms-hf-tuning`. 
 
-### Example: Accelerated GPTQ-LoRA Training
 
-Below we illustrate accelerated quantised PEFT using GPTQ-LoRA tuning with the AutoGPTQ `triton_v2` kernel; this kernel is state-of-the-art [provided by `jeromeku` on Mar 2024](https://github.com/AutoGPTQ/AutoGPTQ/pull/596):
+### Integration with FMS HF Tuning
 
-There is both a *basic* and *advanced* usage low
+
+`fms-acceleration` has already been merged to `fms-hf-tuning`, and the instructions to utilize this repository with [here](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). This reference shows how to use `fms-acceleration` with the [integrated acceleration config dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main/tuning/config/acceleration_configs).
+
+**New exciting [plugins](#plugins) will be added over time, so please check here for the latest accelerations!**.
+
+Also as new plugins become [available here](#plugins), we will also continue to integrate new acceleration config dataclasses into `fms-hf-tuning`. However not all plugins may be integrated, we may omit certain plugins for certain reasons (e.g. stability concerns), and in general integration efforts take time.
+
+To this end, we provide another way to access the plugins in `fms-acceleration` without being integrated into `fms-hf-tuning` dataclasses. 
+The main reason is because we need a way to benchmark and test plugins before `fms-hf-tuning` integration. Thus, we provide a method for `experienced users` to configure the acceleration framework via a configuration YAML via an environment variable. This method has a higher learning curve as it requires the user to know how to understand such a configuration YAML, but it will provide a means to early test new plugins as they become available.
+
+
+### FMS Acceleration Via Configuration YAML
+
+**Note**: As mentioned above, the recomemnded approach for `fms-hf-tuning` is to use the [acceleration config dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). 
+This method documented for the configuration YAML is only for *testing/research purposes* and not recommended for production. For general use, please refer instead [to the instructions here](#integration-with-fms-hf-tuning).
+
+Below we illustrate a configuration YAML flow using the accelerated quantised PEFT using GPTQ-LoRA tuning with the AutoGPTQ `triton_v2` kernel use case; this kernel is state-of-the-art [provided by `jeromeku` on Mar 2024](https://github.com/AutoGPTQ/AutoGPTQ/pull/596):
+
+There is both a *basic* and *advanced* usage for the configuration YAML flow.
 
 ![Usage Flows](img/fms-accel-flows.png)
 
-#### Basic Flow 🤡
+#### Basic Configuration YAML Flow 🤡
 
 Most users of `fms-hf-tuning` only require the basic flow:
-- Assumption 1: user has an already prepared configuration, say from [fms-hf-tuning/fixtures](https://github.com/foundation-model-stack/fms-hf-tuning).
+- Assumption 1: user has an already prepared configuration, say from [sample-configurations](./sample-configurations/accelerated-peft-autogptq-sample-configuration.yaml).
 - Assumption 2: user knows exactly what acceleration 'plugins` are required (based on the configuration).
 - Assumption 3: the arguments for running `sft_trainer.py` is the same; save for one extra argument `--acceleration_framework_config_file` used to pass in the acceleration config.
 
@@ -74,12 +91,12 @@ In this case then the basic flow comprises of 3 steps:
     pip install git+https://github.com/foundation-model-stack/fms-acceleration.git#subdirectory=plugins/accelerated-peft
     ```
 
-5. Run `sft_trainer.py` providing the acceleration configuration and arguments; given the basic flow assumption that we simply re-use the same `sft_trainer.py` arguments as we had without using the `fms_acceleration` package:
+5. Run `sft_trainer.py` providing the acceleration configuration (via the environment variable `ACCELERATION_FRAMEWORK_CONFIG_FILE` and arguments; given the basic flow assumption that we simply re-use the same `sft_trainer.py` arguments as we had without using the `fms_acceleration` package:
     ```
     # when using sample-configurations, arguments can be referred from
     # defaults.yaml and scenarios.yaml
+    ACCELERATION_FRAMEWORK_CONFIG_FILE=framework.yaml \
     python sft_trainer.py \
-        --acceleration_framework_config_file framework.yaml \
         ...  # arguments
     ```
 
@@ -101,9 +118,7 @@ In this case then the basic flow comprises of 3 steps:
     Number of trainable parameters = 13,631,488
     ```
 
-**New exciting [plugins](#plugins) will be added, so please check here for the latest accelerations!**.
-
-#### Advanced Flow 🥷 🦹
+#### Advanced Configuration YAML Flow 🥷 🦹
 
 The advanced flow makes further use of `fms_acceleration.cli` to: 
 * list all available configs and acceleration plugins the configs depend on. 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ Plugin | Description | Depends | License | Status
 
 Below we demonstrate how to accelerate your tuning experience with [tuning/sft_trainer.py](https://github.com/foundation-model-stack/fms-hf-tuning/blob/main/tuning/sft_trainer.py) from `fms-hf-tuning`. 
 
+**Note: New exciting [plugins](#plugins) will be added over time, so please check here for the latest accelerations!**.
 
 ### Integration with FMS HF Tuning
 
 
-`fms-acceleration` has already been merged to `fms-hf-tuning`, and the instructions to utilize this repository with [here](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). This reference shows how to use `fms-acceleration` with the [integrated acceleration config dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main/tuning/config/acceleration_configs).
+`fms-acceleration` is part of `fms-hf-tuning`, and instructions to utilize `fms-acceleration` for tuning are found [here](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). In particular, `fms-acceleration` plugins can be accessed via command line arguments to `fms-hf-tuning` (e.g., `--auto_gptq triton_v2`); this is made available via integrated [configuration dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning/tree/main/tuning/config/acceleration_configs) that configures the `AccelerationFramework` for the user.
 
-**New exciting [plugins](#plugins) will be added over time, so please check here for the latest accelerations!**.
+#### Need for an alternative way to access features pre-integration
 
-Also as new plugins become [available here](#plugins), we will also continue to integrate new acceleration config dataclasses into `fms-hf-tuning`. However not all plugins may be integrated, we may omit certain plugins for certain reasons (e.g. stability concerns), and in general integration efforts take time.
+As new plugins [become available](#plugins), more command line arguments will be made avaiable to `fms-hf-tuning` to enable them. However, this kind of integration takes time; plugins that are in development / research stages may not be immediately integrated.
 
-To this end, we provide another way to access the plugins in `fms-acceleration` without being integrated into `fms-hf-tuning` dataclasses. 
-The main reason is because we need a way to benchmark and test plugins before `fms-hf-tuning` integration. Thus, we provide a method for `experienced users` to configure the acceleration framework via a configuration YAML via an environment variable. This method has a higher learning curve as it requires the user to know how to understand such a configuration YAML, but it will provide a means to early test new plugins as they become available.
+Therefore, an intermediary step is required to access plugins in `fms-acceleration` before they become integrated into `fms-hf-tuning`. In fact, such a method is critical for benchmarking / testing, that needs to happen before integration of any plugin in `fms-hf-tuning` can even be considered. Hence, we provide a method to configure the acceleration framework via a configuration YAML, that is passed into `AccelerationFramework` via an environment variable; the instructions for this is provided below. Futhermore, *experienced users* can also leverage this to early test plugins, but be warned that the learning curve to use these plugins is high (since it requires knowledge on how to write such a configuration). To aid on this, the following instructions are provide that describes both a basic and advanced flow.
 
 
 ### FMS Acceleration Via Configuration YAML
 
-**Note**: As mentioned above, the recomemnded approach for `fms-hf-tuning` is to use the [acceleration config dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). 
+**Note**: As mentioned above, the recommended approach for `fms-hf-tuning` is to use the [acceleration config dataclasses](https://github.com/foundation-model-stack/fms-hf-tuning?tab=readme-ov-file#fms-acceleration). 
 This method documented for the configuration YAML is only for *testing/research purposes* and not recommended for production. For general use, please refer instead [to the instructions here](#integration-with-fms-hf-tuning).
 
 Below we illustrate a configuration YAML flow using the accelerated quantised PEFT using GPTQ-LoRA tuning with the AutoGPTQ `triton_v2` kernel use case; this kernel is state-of-the-art [provided by `jeromeku` on Mar 2024](https://github.com/AutoGPTQ/AutoGPTQ/pull/596):

--- a/plugins/framework/src/fms_acceleration/constants.py
+++ b/plugins/framework/src/fms_acceleration/constants.py
@@ -15,6 +15,8 @@
 KEY_PLUGINS = "plugins"
 PLUGIN_PREFIX = "fms_acceleration_"
 
+ACCELERATION_FRAMEWORK_ENV_KEY = "ACCELERATION_FRAMEWORK_CONFIG_FILE"
+
 # the order below is a linear precedence in which the plugins will be registered
 # and activated.
 # - hence the plugins that have model loaders should be on top of this list

--- a/plugins/framework/src/fms_acceleration/constants.py
+++ b/plugins/framework/src/fms_acceleration/constants.py
@@ -21,7 +21,4 @@ ACCELERATION_FRAMEWORK_ENV_KEY = "ACCELERATION_FRAMEWORK_CONFIG_FILE"
 # and activated.
 # - hence the plugins that have model loaders should be on top of this list
 
-PLUGINS = [
-    "peft",
-    "foak"
-]
+PLUGINS = ["peft", "foak"]

--- a/plugins/framework/src/fms_acceleration/framework.py
+++ b/plugins/framework/src/fms_acceleration/framework.py
@@ -25,7 +25,7 @@ import torch
 import yaml
 
 # Local
-from .constants import KEY_PLUGINS, ACCELERATION_FRAMEWORK_ENV_KEY
+from .constants import ACCELERATION_FRAMEWORK_ENV_KEY, KEY_PLUGINS
 from .framework_plugin import (
     PLUGIN_REGISTRATIONS,
     AccelerationPlugin,
@@ -70,6 +70,7 @@ def log_initialization_message(
         if reg.plugin.__name__ in active_class_names:
             logging_func(_registration_display(reg))
 
+
 def read_configuration_file(configuration_file: str):
     with open(configuration_file, "r", encoding="utf-8") as f:
         contents = yaml.safe_load(f)
@@ -80,19 +81,20 @@ def read_configuration_file(configuration_file: str):
     # pepare the plugin configurations
     return dict(contents[KEY_PLUGINS].items())
 
+
 class AccelerationFramework:
     active_plugins: List[Tuple[str, AccelerationPlugin]] = []
     plugins_require_custom_loading: List = []
 
     def __init__(
-        self, 
-        configuration_file: Optional[str] = None, 
-        require_packages_check: bool = True
+        self,
+        configuration_file: Optional[str] = None,
+        require_packages_check: bool = True,
     ):
         # if configuration_file is none, it could be passed in via the env var
         if (
-            configuration_file is None and 
-            ACCELERATION_FRAMEWORK_ENV_KEY not in os.environ
+            configuration_file is None
+            and ACCELERATION_FRAMEWORK_ENV_KEY not in os.environ
         ):
             raise ValueError(
                 "configuration_file is not passed into configuration_file but "
@@ -106,11 +108,12 @@ class AccelerationFramework:
 
         # if the configuration file was not specified or we cannot
         # get anything out from the configs
-        if (
-            ACCELERATION_FRAMEWORK_ENV_KEY in os.environ and
-            (configuration_file is None or len(plugin_configs) == 0)
+        if ACCELERATION_FRAMEWORK_ENV_KEY in os.environ and (
+            configuration_file is None or len(plugin_configs) == 0
         ):
-            plugin_configs = read_configuration_file(os.environ[ACCELERATION_FRAMEWORK_ENV_KEY])
+            plugin_configs = read_configuration_file(
+                os.environ[ACCELERATION_FRAMEWORK_ENV_KEY]
+            )
 
         # relevant sections are returned following plugin precedence, i.e.,
         # they follow the registration order.

--- a/plugins/framework/src/fms_acceleration/framework.py
+++ b/plugins/framework/src/fms_acceleration/framework.py
@@ -14,6 +14,7 @@
 
 # Standard
 from typing import Callable, List, Optional, Set, Tuple
+import os
 
 # Third Party
 from accelerate import Accelerator
@@ -24,7 +25,7 @@ import torch
 import yaml
 
 # Local
-from .constants import KEY_PLUGINS
+from .constants import KEY_PLUGINS, ACCELERATION_FRAMEWORK_ENV_KEY
 from .framework_plugin import (
     PLUGIN_REGISTRATIONS,
     AccelerationPlugin,
@@ -69,22 +70,47 @@ def log_initialization_message(
         if reg.plugin.__name__ in active_class_names:
             logging_func(_registration_display(reg))
 
+def read_configuration_file(configuration_file: str):
+    with open(configuration_file, "r", encoding="utf-8") as f:
+        contents = yaml.safe_load(f)
+
+    if KEY_PLUGINS not in contents or contents[KEY_PLUGINS] is None:
+        raise ValueError(f"Configuration file must contain a '{KEY_PLUGINS}' body")
+
+    # pepare the plugin configurations
+    return dict(contents[KEY_PLUGINS].items())
 
 class AccelerationFramework:
     active_plugins: List[Tuple[str, AccelerationPlugin]] = []
     plugins_require_custom_loading: List = []
 
     def __init__(
-        self, configuration_file: Optional[str], require_packages_check: bool = True
+        self, 
+        configuration_file: Optional[str] = None, 
+        require_packages_check: bool = True
     ):
-        with open(configuration_file, "r", encoding="utf-8") as f:
-            contents = yaml.safe_load(f)
+        # if configuration_file is none, it could be passed in via the env var
+        if (
+            configuration_file is None and 
+            ACCELERATION_FRAMEWORK_ENV_KEY not in os.environ
+        ):
+            raise ValueError(
+                "configuration_file is not passed into configuration_file but "
+                f"{ACCELERATION_FRAMEWORK_ENV_KEY} is not set. Please choose one "
+                "of the means to initialize the framework."
+            )
 
-        if KEY_PLUGINS not in contents or contents[KEY_PLUGINS] is None:
-            raise ValueError(f"Configuration file must contain a '{KEY_PLUGINS}' body")
+        # read the configs
+        if configuration_file is not None:
+            plugin_configs = read_configuration_file(configuration_file)
 
-        # pepare the plugin configurations
-        plugin_configs = dict(contents[KEY_PLUGINS].items())
+        # if the configuration file was not specified or we cannot
+        # get anything out from the configs
+        if (
+            ACCELERATION_FRAMEWORK_ENV_KEY in os.environ and
+            (configuration_file is None or len(plugin_configs) == 0)
+        ):
+            plugin_configs = read_configuration_file(os.environ[ACCELERATION_FRAMEWORK_ENV_KEY])
 
         # relevant sections are returned following plugin precedence, i.e.,
         # they follow the registration order.

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -343,7 +343,7 @@ class Experiment:
         experiment_arg: List,
         save_dir: str,
         tag: str = None,
-        framework_config: str = None
+        framework_config: str = None,
     ) -> None:
         self.num_gpus = num_gpus
         self.experiment_arg = experiment_arg
@@ -640,9 +640,11 @@ def prepare_arguments(args):
         if args.preload_models and len(products) > 0:
             scenario.preload_models()
 
-        for num_gpus, framework_config, experiment_arg in ConfigUtils.build_args_from_products(
-            products, constants
-        ):
+        for (
+            num_gpus,
+            framework_config,
+            experiment_arg,
+        ) in ConfigUtils.build_args_from_products(products, constants):
             yield num_gpus, framework_config, experiment_arg
 
 
@@ -706,7 +708,7 @@ def gather_report(result_dir: Union[str, List[str]], raw: bool = True):
             except FileNotFoundError:
                 pass
 
-            if script_args["log_nvidia_smi"]:
+            if script_args["log_nvidia_smi"] and tag in experiment_stats:
                 gpu_logs = pd.read_csv(gpu_log_filename, skipinitialspace=True)
                 peak_nvidia_mem_by_device_id, device_name = (
                     get_peak_mem_usage_by_device_id(gpu_logs)
@@ -844,7 +846,9 @@ def main(args):
         device_ids = ",".join(available_gpus_indices[: experiment.num_gpus])
         environment_vars = {"CUDA_VISIBLE_DEVICES": device_ids}
         if experiment.framework_config is not None:
-            environment_vars['ACCELERATION_FRAMEWORK_CONFIG_FILE'] = experiment.framework_config
+            environment_vars["ACCELERATION_FRAMEWORK_CONFIG_FILE"] = (
+                experiment.framework_config
+            )
 
         experiment.run(
             f"{prefix} {FMS_TRAINER}",

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -242,6 +242,9 @@ class ConfigUtils:
         for product in products:
             num_gpus = product.pop("num_gpus")
             effective_batch_size = product.pop("effective_batch_size")
+            framework_config = None
+            if "acceleration_framework_config_file" in product:
+                framework_config = product.pop("acceleration_framework_config_file")
             combined_args = {**product, **defaults}
             argument_list = ConfigUtils.convert_keyvalue_arguments_to_list(
                 combined_args
@@ -252,7 +255,7 @@ class ConfigUtils:
                     str(effective_batch_size // num_gpus),
                 ]
             )
-            args.append((num_gpus, argument_list))
+            args.append((num_gpus, framework_config, argument_list))
         return args
 
     @staticmethod
@@ -340,11 +343,13 @@ class Experiment:
         experiment_arg: List,
         save_dir: str,
         tag: str = None,
+        framework_config: str = None
     ) -> None:
         self.num_gpus = num_gpus
         self.experiment_arg = experiment_arg
         self.result = None
         self.tag = tag
+        self.framework_config = framework_config
 
         # to be set in run
         self.shell_command = None
@@ -499,6 +504,8 @@ class Experiment:
         # save some basic args
         save_result = ConfigUtils.convert_args_to_dict(self.experiment_args_str)
         save_result["num_gpus"] = self.num_gpus
+        if self.framework_config is not None:
+            save_result["acceleration_framework_config_file"] = self.framework_config
 
         # if there is an error we save the error message else we save the final result
         maybe_error_messages = self.maybe_get_experiment_error_traceback()
@@ -632,10 +639,11 @@ def prepare_arguments(args):
         )
         if args.preload_models and len(products) > 0:
             scenario.preload_models()
-        for num_gpus, experiment_arg in ConfigUtils.build_args_from_products(
+
+        for num_gpus, framework_config, experiment_arg in ConfigUtils.build_args_from_products(
             products, constants
         ):
-            yield num_gpus, experiment_arg
+            yield num_gpus, framework_config, experiment_arg
 
 
 def generate_list_of_experiments(
@@ -649,7 +657,7 @@ def generate_list_of_experiments(
     any matrices in scenario and experiment_config
     """
     experiments = []
-    for _expr_id, (num_gpus, exp_arg) in enumerate(experiment_args):
+    for _expr_id, (num_gpus, fcfg, exp_arg) in enumerate(experiment_args):
         experiment_tag = f"{DIR_PREFIX_EXPERIMENT}_{_expr_id}"
         experiment_output_dir = os.path.join(output_dir, experiment_tag)
         expr_arg_w_outputdir = exp_arg + [
@@ -664,6 +672,7 @@ def generate_list_of_experiments(
             expr_arg_w_outputdir,
             save_dir=experiment_output_dir,
             tag=experiment_tag,
+            framework_config=fcfg,
         )
         experiments.append(_expr)
     return experiments
@@ -833,10 +842,13 @@ def main(args):
         devices that each experiment can have access to.
         """
         device_ids = ",".join(available_gpus_indices[: experiment.num_gpus])
+        environment_vars = {"CUDA_VISIBLE_DEVICES": device_ids}
+        if experiment.framework_config is not None:
+            environment_vars['ACCELERATION_FRAMEWORK_CONFIG_FILE'] = experiment.framework_config
 
         experiment.run(
             f"{prefix} {FMS_TRAINER}",
-            environment_variables={"CUDA_VISIBLE_DEVICES": device_ids},
+            environment_variables=environment_vars,
             log_nvidia_smi=args.log_nvidia_smi,
         )
 

--- a/scripts/benchmarks/display_bench_results.py
+++ b/scripts/benchmarks/display_bench_results.py
@@ -32,7 +32,7 @@ def main(
 
     # assume keep and remove are disjoint
     kept = 0
-    if keep_columns: 
+    if keep_columns:
         for c in keep_columns:
             if c in constant:
                 df[c] = constant[c]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
     # need a version of fms-hf-tuning that has integrated the framework
     # NOTE: have to install this first coz havnt merged
     # - this repo has a lot of pins, so we just install it first
-    pip install "fms-hf-tuning[flash-attn] @ git+https://github.com/fabianlim/fms-hf-tuning.git@"{env:FHT_BRANCH:main}
+    pip install "fms-hf-tuning[flash-attn] @ git+https://github.com/foundation-model-stack/fms-hf-tuning.git@"{env:FHT_BRANCH:main}
 
     # some models need this for tokenizers
     pip install protobuf


### PR DESCRIPTION
Since we had changed the integration in `fms-hf-tuning` via dataclasses, this PR fixes the benches but allowing the configuration YAML to be pointed to by an environment variable