### PR TITLE
Bound Package Versions

### DIFF
--- a/plugins/accelerated-peft/requirements.txt
+++ b/plugins/accelerated-peft/requirements.txt
@@ -8,5 +8,6 @@ accelerate < 0.29
 # bitsandbytes for the BNB plugin
 bitsandbytes
 
-# this is because "auto_gptq > 0.7.1" it not yet available
-auto_gptq @ git+https://github.com/AutoGPTQ/AutoGPTQ.git
+# Installing from repository because "auto_gptq > 0.7.1" it not yet available
+# Specifying the commit id here as recent commits to the main branch have introduced additional dependencies
+auto_gptq @ git+https://github.com/AutoGPTQ/AutoGPTQ.git@ea829c7bbe83561c2b1de26795b6592992373ef7

--- a/plugins/framework/pyproject.toml
+++ b/plugins/framework/pyproject.toml
@@ -22,10 +22,12 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
+  "numpy<2.0", # numpy needs to be bounded due to incompatiblity with current torch<2.3
   "torch>2.2,<2.3",
   "transformers<4.40",
   "peft",
-  "accelerate"
+  "accelerate",
+  "trl<0.9", # trl version needs to be constrained until below issue is resolved. https://github.com/foundation-model-stack/fms-hf-tuning/issues/198
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/plugins/framework/tests/__init__.py
+++ b/plugins/framework/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The FMS HF Tuning Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,6 @@ commands =
     # some models need this for tokenizers
     pip install protobuf
 
-    # trl version needs to be constrained until below issue is resolved
-    # https://github.com/foundation-model-stack/fms-hf-tuning/issues/198
-    pip install "trl<0.9"
-
     # install the plugins for test
     # NOTE: when there are more plugins install here
     python -m fms_acceleration.cli install -e {toxinidir}/plugins/accelerated-peft


### PR DESCRIPTION
Bounding package versions to avoid recent incompatibilities for
- AutoGPTQ (Building from latest commit require HPC libraries as dependencies)
- numpy (recently updated to `2.0`, this isnt compatible for torch versions `<2.3`)