### PR TITLE
Publish Accelerated Peft and Fused-Ops Plugins

### DIFF
--- a/plugins/accelerated-peft/tox.ini
+++ b/plugins/accelerated-peft/tox.ini
@@ -38,16 +38,16 @@ commands =
     isort {posargs:.}
 
 
-# [testenv:build]
-# description = build wheel
-# deps =
-#     build
-# commands = python -m build -w
-# skip_install = True
-# 
-# [testenv:twinecheck]
-# description = check wheel
-# deps =
-#     twine
-# commands = twine check dist/*
-# skip_install = True
+[testenv:build]
+description = build wheel
+deps =
+    build
+commands = python -m build -w
+skip_install = True
+
+[testenv:twinecheck]
+description = check wheel
+deps =
+    twine
+commands = twine check dist/*
+skip_install = True

--- a/plugins/framework/src/fms_acceleration/cli.py
+++ b/plugins/framework/src/fms_acceleration/cli.py
@@ -58,8 +58,8 @@ def install_plugin(
         ]
     )
 
-    #Reference from https://github.com/pypa/pip/blob/main/src/pip/_internal/cli/status_codes.py
-    if response>0:
+    # Reference from https://github.com/pypa/pip/blob/main/src/pip/_internal/cli/status_codes.py
+    if response > 0:
         print("PyPi installation failed. Falling back to installation from Github.")
 
         if pkg_name.startswith(PLUGIN_PREFIX):

--- a/plugins/framework/src/fms_acceleration/cli.py
+++ b/plugins/framework/src/fms_acceleration/cli.py
@@ -49,17 +49,29 @@ def install_plugin(
         pipmain(["install", *args, pkg_name])
         return
 
-    if pkg_name.startswith(PLUGIN_PREFIX):
-        pkg_name = pkg_name.replace(PLUGIN_PREFIX, "")
-
     # otherwise should be an internet install
-    pipmain(
+    response = pipmain(
         [
             "install",
             *args,
-            f"git+https://{GITHUB_URL}#subdirectory=plugins/accelerated-{pkg_name}",
+            pkg_name,
         ]
     )
+
+    #Reference from https://github.com/pypa/pip/blob/main/src/pip/_internal/cli/status_codes.py
+    if response>0:
+        print("PyPi installation failed. Falling back to installation from Github.")
+
+        if pkg_name.startswith(PLUGIN_PREFIX):
+            pkg_name = pkg_name.replace(PLUGIN_PREFIX, "")
+
+        pipmain(
+            [
+                "install",
+                *args,
+                f"git+https://{GITHUB_URL}#subdirectory=plugins/accelerated-{pkg_name}",
+            ]
+        )
 
 
 def list_plugins():

--- a/plugins/fused-ops-and-kernels/tox.ini
+++ b/plugins/fused-ops-and-kernels/tox.ini
@@ -45,16 +45,16 @@ commands =
     black --exclude .*unsloth.* tests 
     isort .
 
-# [testenv:build]
-# description = build wheel
-# deps =
-#     build
-# commands = python -m build -w
-# skip_install = True
-# 
-# [testenv:twinecheck]
-# description = check wheel
-# deps =
-#     twine
-# commands = twine check dist/*
-# skip_install = True
+[testenv:build]
+description = build wheel
+deps =
+    build
+commands = python -m build -w
+skip_install = True
+
+[testenv:twinecheck]
+description = check wheel
+deps =
+    twine
+commands = twine check dist/*
+skip_install = True


### PR DESCRIPTION
This PR prepares the accelerated-peft and fused-ops-and-kernels plugins for publishing.

Items:
- Change Framework CLI tool to support installation from PyPi
- Set version numbers for both plugin package
- Enable tox build sections for both plugins

