### PR TITLE
Local autogptq fix

### DIFF
--- a/plugins/accelerated-peft/README.md
+++ b/plugins/accelerated-peft/README.md
@@ -19,9 +19,18 @@ Plugin | Description | Depends | Loading | Augmentation | Callbacks
 ## Known Issues
 
 - Models with sliding windows (e.g., Mistral, Mixtral) will have [memory and throughout issues](https://github.com/huggingface/transformers/issues/30461).
-- GPTQ-LORA sometimes observed to have `nan` grad norms in the begining of training, but training proceeds well otherwise.
+- GPTQ-LORA sometimes observed to have `nan` grad norms in the begining of training, but training pr.
 - `low_cpu_mem_usage` temporarily disabled for AutoGPTQ until bug with `make_sure_no_tensor_in_meta_device` is resolved.
-- Requires nightly [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ) until package `> 0.7.1` becomes available
+- The legacy implementation of GPTQ-LORA uses an external AutoGPTQ package, you must ensure the package is installed
     ```
-    pip install git+https://github.com/AutoGPTQ/AutoGPTQ.git
+    pip install git+https://github.com/AutoGPTQ/AutoGPTQ.git@ea829c7bbe83561c2b1de26795b6592992373ef7
     ```
+- To construct the plugin with the legacy implementation that uses an external AutoGPTQ package, in the configuration object that is passed to the plugin - set `use_external_lib = True` (default is set to False to use the local AutoGPTQ package)
+```
+    peft:
+    quantization: 
+        auto_gptq:
+        kernel: triton_v2
+        from_quantized: True
+        use_external_lib: True
+```

--- a/plugins/accelerated-peft/README.md
+++ b/plugins/accelerated-peft/README.md
@@ -16,21 +16,33 @@ Plugin | Description | Depends | Loading | Augmentation | Callbacks
 - `triton_v2` kernels are not yet properly integrated into huggingface optimum.
 - `triton_v2` kernels are [the only 4bit kernels that work for training](https://github.com/AutoGPTQ/AutoGPTQ/issues/633).
 
+## GPTQ-LORA's AutoGPTQ - Current Implementation vs Legacy Implementation
+
+GPTQ-LORA depends on an AutoGPTQ backend to run. There are 2 backend options
+
+1. Current Implementation
+    - This is an extracted local subset from [ModelCloud's](https://github.com/ModelCloud/GPTQModel) refactored fork.
+    - It removes redundant code to simplify build and installation of the plugin
+2. Legacy Implementation
+    - This requires building the package from the official AutoGPTQ repository
+    - To replicate this implementation, follow the installation below
+
+        - The legacy implementation of GPTQ-LORA uses an external AutoGPTQ package, you must ensure the specific commit is installed
+            ```
+            pip install git+https://github.com/AutoGPTQ/AutoGPTQ.git@ea829c7bbe83561c2b1de26795b6592992373ef7
+            ```
+        - To construct the plugin, in the configuration object that is passed to the plugin - set `use_external_lib: True` (otherwise defaults to use the local AutoGPTQ package)
+        ```
+            peft:
+            quantization: 
+                auto_gptq:
+                kernel: triton_v2
+                from_quantized: True
+                use_external_lib: True
+        ```
+
 ## Known Issues
 
 - Models with sliding windows (e.g., Mistral, Mixtral) will have [memory and throughout issues](https://github.com/huggingface/transformers/issues/30461).
-- GPTQ-LORA sometimes observed to have `nan` grad norms in the begining of training, but training pr.
+- GPTQ-LORA sometimes observed to have `nan` grad norms in the begining of training, but training proceeds well otherwise.
 - `low_cpu_mem_usage` temporarily disabled for AutoGPTQ until bug with `make_sure_no_tensor_in_meta_device` is resolved.
-- The legacy implementation of GPTQ-LORA uses an external AutoGPTQ package, you must ensure the package is installed
-    ```
-    pip install git+https://github.com/AutoGPTQ/AutoGPTQ.git@ea829c7bbe83561c2b1de26795b6592992373ef7
-    ```
-- To construct the plugin with the legacy implementation that uses an external AutoGPTQ package, in the configuration object that is passed to the plugin - set `use_external_lib = True` (default is set to False to use the local AutoGPTQ package)
-```
-    peft:
-    quantization: 
-        auto_gptq:
-        kernel: triton_v2
-        from_quantized: True
-        use_external_lib: True
-```

--- a/plugins/accelerated-peft/configs/autogptq.yaml
+++ b/plugins/accelerated-peft/configs/autogptq.yaml
@@ -17,3 +17,8 @@ peft:
       # If true, then will already expect quantized checkpoint 
       # passed into TrainingArguments.model_name_or_path
       from_quantized: True
+
+      # Setting to false, will create GPTQ-LORA using the local autogptq package.
+      # if true, will create legacy implementation of GPTQ-LORA using external 
+      # `auto_gptq`. Refer to README for installation instructions
+      use_external_lib: False

--- a/plugins/accelerated-peft/pyproject.toml
+++ b/plugins/accelerated-peft/pyproject.toml
@@ -26,7 +26,6 @@ classifiers=[
 
 [project.optional-dependencies]
 flash-attn = ["flash-attn"]
-auto_gptq = ["auto_gptq @ git+https://github.com/AutoGPTQ/AutoGPTQ.git@ea829c7bbe83561c2b1de26795b6592992373ef7"] # known working commitid
 
 [tool.hatch.metadata.hooks.requirements_txt]
 files = ["requirements.txt"]

--- a/plugins/accelerated-peft/requirements.txt
+++ b/plugins/accelerated-peft/requirements.txt
@@ -10,4 +10,6 @@ bitsandbytes
 # Used to manage the thread limit in functions for converting old 
 # GPTQ models to new GPTQ model format that support symmetrical=False
 # https://github.com/AutoGPTQ/AutoGPTQ/pull/640
-threadpoolctl
+threadpoolctl >= 3.5.0
+
+datasets >= 2.20.0

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -28,7 +28,6 @@ from peft import LoraConfig, prepare_model_for_kbit_training
 from peft.tuners.lora.model import LoraModel
 from transformers import AutoModelForCausalLM, TrainingArguments
 from transformers.modeling_utils import is_fsdp_enabled
-from transformers.utils.import_utils import _is_package_available
 import torch
 import torch.distributed
 
@@ -53,6 +52,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         )
 
         if self.use_external_lib:
+            from transformers.utils.import_utils import _is_package_available # pylint: disable=import-outside-toplevel
             assert (
                 _is_package_available("auto_gptq") is True
             ), "Unable to use external library, auto_gptq module not found. \

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -57,9 +57,11 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             from transformers.utils.import_utils import _is_package_available # pylint: disable=import-outside-toplevel
             assert (
                 _is_package_available("auto_gptq") is True
-            ), "Unable to use external library, auto_gptq module not found. \
-                Refer to README for installation instructions \
-                as a specific version might be required."
+            ),  (
+               "Unable to use external library, auto_gptq module not found. "
+                "Refer to README for installation instructions  "
+                "as a specific version might be required."
+            )
 
     def model_loader(self, model_name: str, **kwargs):
         # guarded imports

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -48,7 +48,9 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             key="peft.quantization.auto_gptq.from_quantized", value=True
         )
         self.use_external_lib = self._check_config_and_maybe_check_values(
-            key="peft.quantization.auto_gptq.use_external_lib", values=[True, False]
+            key="peft.quantization.auto_gptq.use_external_lib", 
+            values=[True, False],
+            default=False,
         )
 
         if self.use_external_lib:

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -48,7 +48,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             key="peft.quantization.auto_gptq.from_quantized", value=True
         )
         self.use_external_lib = self._check_config_and_maybe_check_values(
-            key="peft.quantization.auto_gptq.use_external_lib", 
+            key="peft.quantization.auto_gptq.use_external_lib",
             values=[True, False],
             default=False,
         )

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -37,7 +37,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
 
     require_packages = []
 
-    def __init__(self, configurations: Dict[str, Dict], use_external_lib: bool = False):
+    def __init__(self, configurations: Dict[str, Dict]):
         super().__init__(configurations)
 
         # just do checking, nothing must to configure at this point
@@ -48,12 +48,16 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         self._check_config_equal(
             key="peft.quantization.auto_gptq.from_quantized", value=True
         )
-        self.use_external_lib = use_external_lib
+        self.use_external_lib = self._check_config_and_maybe_check_values(
+            key="peft.quantization.auto_gptq.use_external_lib", values=[True, False]
+        )
 
         if self.use_external_lib:
             assert (
                 _is_package_available("auto_gptq") is True
-            ), "Unable to use external library, autogptq module not found."
+            ), "Unable to use external library, auto_gptq module not found. \
+                Refer to README for installation instructions \
+                as a specific version might be required."
 
     def model_loader(self, model_name: str, **kwargs):
         # guarded imports

--- a/plugins/accelerated-peft/tests/test_gptqmodel.py
+++ b/plugins/accelerated-peft/tests/test_gptqmodel.py
@@ -63,11 +63,14 @@ def load_autogptq_plugin_model(
         {
             "peft": {
                 "quantization": {
-                    "auto_gptq": {"kernel": "triton_v2", "from_quantized": True}
+                    "auto_gptq": {
+                        "kernel": "triton_v2", 
+                        "from_quantized": True, 
+                        "use_external_lib": use_external_lib,
+                        }
                 }
             }
         },
-        use_external_lib=use_external_lib,
     )
 
     class TrainArgs:

--- a/plugins/accelerated-peft/tests/test_peft_plugins.py
+++ b/plugins/accelerated-peft/tests/test_peft_plugins.py
@@ -90,6 +90,7 @@ def test_configure_gptq_plugin():
         e.match(f"AutoGPTQAccelerationPlugin: Value at '{key}'")
 
 def test_autogptq_loading():
+    "Test for correctness of autogptq loading logic"
     def autogptq_unavailable(package_name: str):
         return False
 
@@ -99,9 +100,8 @@ def test_autogptq_loading():
     # 3. check when using external package and it is not available, an AssertionError is thrown
     with pytest.raises(
         AssertionError,
-        match = "Unable to use external library, auto_gptq module not found. \
-                Refer to README for installation instructions \
-                as a specific version might be required."
+        match = "Unable to use external library, auto_gptq module not found. "
+        "Refer to README for installation instructions  as a specific version might be required."
     ):
         with patch(
                     "transformers.utils.import_utils."
@@ -141,7 +141,7 @@ def test_autogptq_loading():
     ) as framework:
         model = framework.model_loader(MODEL_NAME_AUTO_GPTQ)
         assert any(isinstance(mod, QuantLinear) for mod in model.modules()), \
-        "use_external_lib=False, but local autogptq package not used by model"
+        "use_external_lib=None, but local autogptq package not used by model"
 
 # We do not enable the skip since this test does not actually require the packages
 # installed

--- a/plugins/accelerated-peft/tox.ini
+++ b/plugins/accelerated-peft/tox.ini
@@ -7,12 +7,13 @@ deps =
     # for the tests, we need to install the deps ourselves
     # as the package will install the github version    
     -e {toxinidir}/../framework
+    -r {toxinidir}/requirements.txt
 # set skip package installation as it will install package pyproject.toml before deps, will throw error when AutoGPTQ needs torch
 skip_install = true 
 commands = 
     # install the current package
     pip install --no-deps {toxinidir}
-    pip install threadpoolctl protobuf sentencepiece datasets # these packages are required for some tests
+    pip install protobuf sentencepiece # these packages are required for some tests
     pytest {posargs:tests}
 
 [testenv:lint] 

--- a/plugins/accelerated-peft/tox.ini
+++ b/plugins/accelerated-peft/tox.ini
@@ -12,7 +12,7 @@ skip_install = true
 commands = 
     # install the current package
     pip install --no-deps {toxinidir}
-    pip install threadpoolctl protobuf sentencepiece # these packages are required for some tests
+    pip install threadpoolctl protobuf sentencepiece datasets # these packages are required for some tests
     pytest {posargs:tests}
 
 [testenv:lint] 

--- a/plugins/framework/src/fms_acceleration/framework_plugin.py
+++ b/plugins/framework/src/fms_acceleration/framework_plugin.py
@@ -169,9 +169,8 @@ class AccelerationPlugin:
                         f"{self.__class__.__name__}: Value at '{key}' was '{t}'. "
                         f"Not found in expected set '{values}'."
                     )
-                else:
-                    # otherwise if there is a default, then take it
-                    t = default
+                # otherwise if there is a default, then take it
+                t = default
         else:
             # if nothing to check against, and no default, we still
             # need to ensure its a valid configuration key
@@ -180,9 +179,7 @@ class AccelerationPlugin:
                     raise AccelerationPluginConfigError(
                         f"{self.__class__.__name__}: '{key}' was not a valid configuration config"
                     )
-                else:
-                    # otherwise if there is a default, then take it
-                    t = default
+                t = default
 
         return t
 

--- a/plugins/framework/src/fms_acceleration/framework_plugin.py
+++ b/plugins/framework/src/fms_acceleration/framework_plugin.py
@@ -148,7 +148,9 @@ class AccelerationPlugin:
     ):
         return []
 
-    def _check_config_and_maybe_check_values(self, key: str, values: List[Any] = None):
+    def _check_config_and_maybe_check_values(
+        self, key: str, values: List[Any] = None, default: Any = None
+    ):
         t = _trace_key_path(self.configurations, key)
 
         if values is not None:  # if there is something to check against
@@ -162,17 +164,25 @@ class AccelerationPlugin:
                 t = list(t.keys())[0]  # otherwise take the first value
 
             if t not in values:
-                raise AccelerationPluginConfigError(
-                    f"{self.__class__.__name__}: Value at '{key}' was '{t}'. "
-                    "Not found in expected set '{values}'."
-                )
+                if default is None:
+                    raise AccelerationPluginConfigError(
+                        f"{self.__class__.__name__}: Value at '{key}' was '{t}'. "
+                        f"Not found in expected set '{values}'."
+                    )
+                else:
+                    # otherwise if there is a default, then take it
+                    t = default
         else:
-            # if nothing to check against, we still want to ensure its a valid
-            # configuration key
+            # if nothing to check against, and no default, we still
+            # need to ensure its a valid configuration key
             if t is None:
-                raise AccelerationPluginConfigError(
-                    f"{self.__class__.__name__}: '{key}' was not a valid configuration config"
-                )
+                if default is None:
+                    raise AccelerationPluginConfigError(
+                        f"{self.__class__.__name__}: '{key}' was not a valid configuration config"
+                    )
+                else:
+                    # otherwise if there is a default, then take it
+                    t = default
 
         return t
 

--- a/sample-configurations/accelerated-peft-autogptq-foak-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-autogptq-foak-sample-configuration.yaml
@@ -22,6 +22,11 @@ plugins:
           # If true, then will already expect quantized checkpoint 
           # passed into TrainingArguments.model_name_or_path
         from_quantized: true
+
+          # Setting to false, will create GPTQ-LORA using the local autogptq package.
+          # if true, will create legacy implementation of GPTQ-LORA using external 
+          # `auto_gptq`. Refer to README for installation instructions
+        use_external_lib: false
       fused_ops_and_kernels:
 
         # load unsloth optimizations for these 4bit base layer weights.

--- a/sample-configurations/accelerated-peft-autogptq-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-autogptq-sample-configuration.yaml
@@ -22,3 +22,8 @@ plugins:
         # If true, then will already expect quantized checkpoint 
         # passed into TrainingArguments.model_name_or_path
         from_quantized: true
+
+        # Setting to false, will create GPTQ-LORA using the local autogptq package.
+        # if true, will create legacy implementation of GPTQ-LORA using external 
+        # `auto_gptq`. Refer to README for installation instructions
+        use_external_lib: false


### PR DESCRIPTION
## Description

This PR applies additional fixes to #48,

### Fixed items:
- removed direct dependency in plugin
- edited plugin README with information to install direct dependencies when creating a legacy GPTQ-LORA
- Shifted `use_external_lib` argument from plugin argument to configuration object field
- Added additional unit tests to ensure 
    - the new field is read
    - the correct package is imported
    - appropriate errors are thrown
- regenerated sample configuration yamls to include the new field

### FMS-Acceleration-Peft Unit Test
```
============================================================================================================================================================================================================ test session starts ============================================================================================================================================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /data/aaron/experimental/fms-acceleration/plugins/accelerated-peft
configfile: pyproject.toml
collected 8 items                                                                                                                                                                                                                                                                                                                                                                                                                           

tests/test_gptqmodel.py ..                                                                                                                                                                                                                                                                                                                                                                                                            [ 25%]
tests/test_peft_plugins.py ...                                                                                                                                                                                                                                                                                                                                                                                                        [ 62%]
tests/test_q4_triton.py ..                                                                                                                                                                                                                                                                                                                                                                                                            [ 87%]
tests/test_triton.py .                                                                                                                                                                                                                                                                                                                                                                                                                [100%]

============================================================================================================================================================================================================= warnings summary ==============================================================================================================================================================================================================
.tox/py/lib/python3.10/site-packages/transformers/utils/hub.py:124
  /data/aaron/experimental/fms-acceleration/plugins/accelerated-peft/.tox/py/lib/python3.10/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
    warnings.warn(

tests/test_gptqmodel.py::test_pre_quantized_model_outputs_match
tests/test_gptqmodel.py::test_quantizing_pretrained_model_outputs_match
tests/test_gptqmodel.py::test_quantizing_pretrained_model_outputs_match
tests/test_peft_plugins.py::test_autogptq_loading
tests/test_q4_triton.py::TestsQ4Triton::test_generation_desc_act_false
tests/test_q4_triton.py::TestsQ4Triton::test_generation_desc_act_true
tests/test_triton.py::TestTriton::test_triton_qlinear
  /data/aaron/experimental/fms-acceleration/plugins/accelerated-peft/.tox/py/lib/python3.10/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
    warnings.warn(

tests/test_gptqmodel.py::test_pre_quantized_model_outputs_match
  /data/aaron/experimental/fms-acceleration/plugins/accelerated-peft/.tox/py/lib/python3.10/site-packages/auto_gptq/utils/peft_utils.py:360: UserWarning: You can just ignore this warning if the peft type you use isn't in ['LORA', 'ADALORA'].
  LlamaGPTQForCausalLM supports injecting fused attention but not enables this time. If you are training adapters, you must also disable fused attention injection when loading quantized base model at inference time, otherwise adapters may not be added to base model properly. If you are loading adapters to do inference, you can reference to adapter's config file to check whether the adapters are trained using base model that n
ot enable fused attention injection.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================================================================================= 8 passed, 9 warnings in 140.29s (0:02:20) =================================================================================================================================================================================================
```

### FMS-HF-Tuning Acceleration Unit Test
```
============================================================================================================================================================================================================= warnings summary ==============================================================================================================================================================================================================
../fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/transformers/utils/hub.py:124
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/transformers/utils/hub.py:124: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_raises_due_to_invalid_arguments[triton_v2 requires fp16]
tests/acceleration/test_acceleration_framework.py::test_framework_raises_due_to_invalid_arguments[accelerated peft requires peft config]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/transformers/training_args.py:1847: FutureWarning: `--push_to_hub_token` is deprecated and will be removed in version 5 of 🤗 Transformers. Use `--hub_token` instead.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/huggingface_hub/utils/_deprecation.py:100: FutureWarning: Deprecated argument(s) used in '__init__': dataset_text_field, max_seq_length. Will not be supported from version '1.0.0'.
  
  Deprecated positional argument(s) used in SFTTrainer, please use the SFTConfig to set these arguments instead.
    warnings.warn(message, FutureWarning)

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/trl/trainer/sft_trainer.py:269: UserWarning: You passed a `max_seq_length` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/trl/trainer/sft_trainer.py:307: UserWarning: You passed a `dataset_text_field` argument to the SFTTrainer, the value you passed will override the one in the `SFTConfig`.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/trl/trainer/sft_trainer.py:397: UserWarning: You passed a tokenizer with `padding_side` not equal to `right` to the SFTTrainer. This might lead to some unexpected behaviour due to overflow issues when training a model in half-precision. You might consider adding `tokenizer.padding_side = 'right'` to your code.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[bitsandbytes]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_peft[auto_gptq]
tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-acceleration/.tox/run-benches/lib/python3.10/site-packages/accelerate/accelerator.py:447: FutureWarning: Passing the following arguments to `Accelerator` is deprecated and will be removed in version 1.0 of Accelerate: dict_keys(['dispatch_batches', 'split_batches', 'even_batches', 'use_seedable_sampler']). Please pass an `accelerate.DataLoaderConfiguration` instead: 
  dataloader_config = DataLoaderConfiguration(dispatch_batches=None, split_batches=False, even_batches=True, use_seedable_sampler=True)
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-hf-tuning/tuning/config/acceleration_configs/acceleration_framework_config.py:244: UserWarning: An experimental acceleration feature is requested by specifying the '--fused_lora' argument. Please note this feature may not support certain edge cases at this juncture. When the feature matures this message will be turned off.
    warnings.warn(

tests/acceleration/test_acceleration_framework.py::test_framework_intialized_properly_foak
  /data/aaron/experimental/fms-hf-tuning/tuning/config/acceleration_configs/acceleration_framework_config.py:244: UserWarning: An experimental acceleration feature is requested by specifying the '--fast_kernels' argument. Please note this feature may not support certain edge cases at this juncture. When the feature matures this message will be turned off.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================================================================================================================== short test summary info ==========================================================================================================================================================================================================
SKIPPED [1] tests/acceleration/test_acceleration_framework.py:164:  NOTE: this scenario will actually never happen, since in the code we always
    provide at least one dataclass (can consider to remove this test).
================================================================================================================================================================================================ 13 passed, 1 skipped, 27 warnings in 47.64s ================================================================================================================================================================================================
```