### PR TITLE
Fix Mistakes with FA Padding Free

### DIFF
--- a/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
+++ b/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import inspect
+from functools import partial
 import torch
-from transformers.utils import is_flash_attn_2_available
+from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal
 from types import MethodType
+from typing import Optional
 
 if is_flash_attn_2_available():
-    from flash_attn import flash_attn_varlen_func # pylint: disable=import-error
+    from flash_attn import flash_attn_func, flash_attn_varlen_func # pylint: disable=import-error
+    _flash_supports_window_size = "window_size" in list(inspect.signature(flash_attn_func).parameters)
 
 def prepare_fa2_from_position_ids(query, key, value, position_ids, query_length):
     query = query.view(-1, query.size(-2), query.size(-1))
@@ -28,81 +33,133 @@ def prepare_fa2_from_position_ids(query, key, value, position_ids, query_length)
     cu_seq_lens = torch.cat((
         indices_q[position_ids==0],
         torch.tensor(position_ids.size(), device=position_ids.device, dtype=torch.int32)
-        ))
+    ))
     max_length = position_ids.max()+1
     return (query, key, value, indices_q, (cu_seq_lens, cu_seq_lens), (max_length, max_length))
 
-def build_fa_forward(
-    attention: torch.nn.Module, causal: bool = True, dropout: float = None
+# model id -> position_ids
+POSITION_IDS_CACHE = {}
+
+# - needed to store position ids when first come into model
+# will pass these to the flash attention function
+def build2(
+    model: torch.nn.Module, model_id: str,
 ):
-    # assert not hasattr(self, '_position_ids'), "cannot patch fa attention"
+    # forward
+    old_forward = model.forward
 
-    position_ids: torch.Tensor = None
-    old_forward = attention.forward
-    if dropout is not None:
-        attention.dropout = torch.nn.Dropout(p=dropout)
-
+    # the model will get out the position
     def forward(self, *args, **kwargs):
-        nonlocal position_ids
-        position_ids = kwargs['position_ids']
+        # store position ids
+        POSITION_IDS_CACHE[model_id] = kwargs['position_ids']
+        return old_forward(*args, **kwargs)
+
+    return forward
+  
+def build_fa_forward(
+    attention: torch.nn.Module, model_id: str,
+):
+
+    # this is really a dummpy replace 
+    old_forward = attention.forward
+    def forward(self, *args, **kwargs):
         out, *others = old_forward(*args, **kwargs)
-        if dropout is not None:
-            out = self.dropout(out)
         return out, *others
 
-    def _flash_attention_forward(
-        self,
-        query_states,
-        key_states,
-        value_states,
-        attention_mask,
-        query_length,
-        dropout=0.0,
-        softmax_scale=None,
-        **kwargs,
-    ):
-        # if not self._flash_attn_uses_top_left_mask:
-        #     causal = self.is_causal
-        # else:
-        #     # TODO: Remove the `query_length != 1`
-        #     # check once Flash Attention for RoCm is bumped to 2.1.
-        #     # For details, please see the comment in LlamaFlashAttention2 __init__.
-        #     causal = self.is_causal and query_length != 1
+    _flash_attn = partial(
+        _flash_attention_forward_with_posids, model_id
+    )
 
-        assert attention_mask is None, "should not be using attention mask"
-        assert position_ids is not None, "should be expecting position ids"
-        batch_size = query_states.size(0)
-        (
-            query_states,
-            key_states,
-            value_states,
-            _,
-            cu_seq_lens,
-            max_seq_lens,
-        ) = prepare_fa2_from_position_ids(
-            query_states, key_states, value_states, position_ids, query_length
-        )
-
-        cu_seqlens_q, cu_seqlens_k = cu_seq_lens
-        max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
-
-        attn_output = flash_attn_varlen_func(
-            query_states,
-            key_states,
-            value_states,
-            cu_seqlens_q=cu_seqlens_q,
-            cu_seqlens_k=cu_seqlens_k,
-            max_seqlen_q=max_seqlen_in_batch_q,
-            max_seqlen_k=max_seqlen_in_batch_k,
-            dropout_p=dropout,
-            softmax_scale=softmax_scale,
-            causal=causal,
-        )
-
-        return attn_output.view(batch_size, -1, attn_output.size(-2), attn_output.size(-1))
-
-    # do this replace
-    attention._flash_attention_forward = MethodType(_flash_attention_forward, attention)
+    # do this replace of a method with a static
+    attention._flash_attention_forward = _flash_attn
 
     # return the forward
     return forward
+
+# FIXME: it is difficult to keep up with all the different versions
+# - this is a generic version that accepts 
+def _flash_attention_forward_with_posids(
+    model_id: str,
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    attention_mask: torch.Tensor,
+    query_length: int,
+    is_causal: bool = True, # make this optional to support < 4.43
+    dropout: float = 0.0,
+    position_ids: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    sliding_window: Optional[int] = None,
+    use_top_left_mask: bool = False,
+    softcap: Optional[float] = None,
+    deterministic: bool = None,
+    **kwargs,
+):
+    """
+    Calls the forward method of Flash Attention - if the input hidden states contain at least one padding token
+    first unpad the input, then computes the attention scores and pad the final attention scores.
+    """
+    position_ids = POSITION_IDS_CACHE[model_id]
+    
+    if not use_top_left_mask:
+        causal = is_causal
+    else:
+        # TODO: Remove the `query_length != 1` check once Flash Attention for RoCm is bumped to 2.1. For details, please see the comment in transformers.models.llama.modeling_llama.LlamaFlashAttention2.__init__.
+        causal = is_causal and query_length != 1
+
+    # for supporting < 4.43
+    use_sliding_windows = kwargs.get("use_sliding_windows")
+    if use_sliding_windows is None:
+        # Assuming 4D tensors, key_states.shape[1] is the key/value sequence length (source length).
+        use_sliding_windows = (
+            _flash_supports_window_size and sliding_window is not None and key_states.shape[1] > sliding_window
+        )
+    flash_kwargs = {"window_size": (sliding_window, sliding_window)} if use_sliding_windows else {}
+
+    try:
+        if is_flash_attn_greater_or_equal("2.4.1"):
+            if deterministic is None:
+                deterministic = os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
+            flash_kwargs["deterministic"] = deterministic
+    except:
+        # FIXME: is_flash_attn_greater_or_equal expects a version
+        # object for < 4.43
+        pass
+
+    if softcap is not None:
+        flash_kwargs["softcap"] = softcap
+
+    assert attention_mask is None, "should not be using attention mask"
+    assert position_ids is not None, "should be expecting position ids"
+    batch_size = query_states.size(0)
+    (
+        query_states,
+        key_states,
+        value_states,
+        _,
+        cu_seq_lens,
+        max_seq_lens,
+    ) = prepare_fa2_from_position_ids(
+        query_states, key_states, value_states, position_ids, query_length
+    )
+
+    cu_seqlens_q, cu_seqlens_k = cu_seq_lens
+    max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
+
+    attn_output = flash_attn_varlen_func(
+        query_states,
+        key_states,
+        value_states,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_in_batch_q,
+        max_seqlen_k=max_seqlen_in_batch_k,
+        dropout_p=dropout,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        **flash_kwargs,
+    )
+
+    attn_output = attn_output.view(batch_size, -1, attn_output.size(-2), attn_output.size(-1))
+
+    return attn_output

--- a/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
+++ b/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
@@ -17,7 +17,6 @@ import inspect
 from functools import partial
 import torch
 from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal
-from types import MethodType
 from typing import Optional
 
 if is_flash_attn_2_available():
@@ -42,7 +41,7 @@ POSITION_IDS_CACHE = {}
 
 # - needed to store position ids when first come into model
 # will pass these to the flash attention function
-def build2(
+def build_backbone_forward(
     model: torch.nn.Module, model_id: str,
 ):
     # forward
@@ -122,8 +121,9 @@ def _flash_attention_forward_with_posids(
                 deterministic = os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
             flash_kwargs["deterministic"] = deterministic
     except:
-        # FIXME: is_flash_attn_greater_or_equal expects a version
+        # FIXME: is_flash_attn_greater_or_equal expects a packaging.version
         # object for < 4.43
+        # - we just assume that this deterministic flag is not impt
         pass
 
     if softcap is not None:

--- a/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
+++ b/plugins/instruct-lab/src/fms_acceleration_ilab/flash_attn.py
@@ -16,33 +16,59 @@ import os
 import inspect
 from functools import partial
 import torch
+
+# pylint: disable=no-name-in-module
 from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal
 from typing import Optional
 
 if is_flash_attn_2_available():
-    from flash_attn import flash_attn_func, flash_attn_varlen_func # pylint: disable=import-error
-    _flash_supports_window_size = "window_size" in list(inspect.signature(flash_attn_func).parameters)
+    # pylint: disable=import-error
+    from flash_attn import (
+        flash_attn_func,
+        flash_attn_varlen_func,
+    )
+
+    _flash_supports_window_size = "window_size" in list(
+        inspect.signature(flash_attn_func).parameters
+    )
+
 
 def prepare_fa2_from_position_ids(query, key, value, position_ids, query_length):
     query = query.view(-1, query.size(-2), query.size(-1))
     key = key.view(-1, key.size(-2), key.size(-1))
     value = value.view(-1, value.size(-2), value.size(-1))
     position_ids = position_ids.flatten()
-    indices_q = torch.arange(position_ids.size(0), device=position_ids.device, dtype=torch.int32)
-    cu_seq_lens = torch.cat((
-        indices_q[position_ids==0],
-        torch.tensor(position_ids.size(), device=position_ids.device, dtype=torch.int32)
-    ))
-    max_length = position_ids.max()+1
-    return (query, key, value, indices_q, (cu_seq_lens, cu_seq_lens), (max_length, max_length))
+    indices_q = torch.arange(
+        position_ids.size(0), device=position_ids.device, dtype=torch.int32
+    )
+    cu_seq_lens = torch.cat(
+        (
+            indices_q[position_ids == 0],
+            torch.tensor(
+                position_ids.size(), device=position_ids.device, dtype=torch.int32
+            ),
+        )
+    )
+    max_length = position_ids.max() + 1
+    return (
+        query,
+        key,
+        value,
+        indices_q,
+        (cu_seq_lens, cu_seq_lens),
+        (max_length, max_length),
+    )
+
 
 # model id -> position_ids
 POSITION_IDS_CACHE = {}
 
+
 # - needed to store position ids when first come into model
 # will pass these to the flash attention function
 def build_backbone_forward(
-    model: torch.nn.Module, model_id: str,
+    model: torch.nn.Module,
+    model_id: str,
 ):
     # forward
     old_forward = model.forward
@@ -50,24 +76,25 @@ def build_backbone_forward(
     # the model will get out the position
     def forward(self, *args, **kwargs):
         # store position ids
-        POSITION_IDS_CACHE[model_id] = kwargs['position_ids']
+        POSITION_IDS_CACHE[model_id] = kwargs["position_ids"]
         return old_forward(*args, **kwargs)
 
     return forward
-  
+
+
 def build_fa_forward(
-    attention: torch.nn.Module, model_id: str,
+    attention: torch.nn.Module,
+    model_id: str,
 ):
 
-    # this is really a dummpy replace 
+    # this is really a dummpy replace
     old_forward = attention.forward
+
     def forward(self, *args, **kwargs):
         out, *others = old_forward(*args, **kwargs)
         return out, *others
 
-    _flash_attn = partial(
-        _flash_attention_forward_with_posids, model_id
-    )
+    _flash_attn = partial(_flash_attention_forward_with_posids, model_id)
 
     # do this replace of a method with a static
     attention._flash_attention_forward = _flash_attn
@@ -75,8 +102,9 @@ def build_fa_forward(
     # return the forward
     return forward
 
+
 # FIXME: it is difficult to keep up with all the different versions
-# - this is a generic version that accepts 
+# - this is a generic version that accepts
 def _flash_attention_forward_with_posids(
     model_id: str,
     query_states: torch.Tensor,
@@ -84,9 +112,8 @@ def _flash_attention_forward_with_posids(
     value_states: torch.Tensor,
     attention_mask: torch.Tensor,
     query_length: int,
-    is_causal: bool = True, # make this optional to support < 4.43
+    is_causal: bool = True,  # make this optional to support < 4.43
     dropout: float = 0.0,
-    position_ids: Optional[torch.Tensor] = None,
     softmax_scale: Optional[float] = None,
     sliding_window: Optional[int] = None,
     use_top_left_mask: bool = False,
@@ -94,16 +121,12 @@ def _flash_attention_forward_with_posids(
     deterministic: bool = None,
     **kwargs,
 ):
-    """
-    Calls the forward method of Flash Attention - if the input hidden states contain at least one padding token
-    first unpad the input, then computes the attention scores and pad the final attention scores.
-    """
+    # get the position ids out here
     position_ids = POSITION_IDS_CACHE[model_id]
-    
+
     if not use_top_left_mask:
         causal = is_causal
     else:
-        # TODO: Remove the `query_length != 1` check once Flash Attention for RoCm is bumped to 2.1. For details, please see the comment in transformers.models.llama.modeling_llama.LlamaFlashAttention2.__init__.
         causal = is_causal and query_length != 1
 
     # for supporting < 4.43
@@ -111,18 +134,24 @@ def _flash_attention_forward_with_posids(
     if use_sliding_windows is None:
         # Assuming 4D tensors, key_states.shape[1] is the key/value sequence length (source length).
         use_sliding_windows = (
-            _flash_supports_window_size and sliding_window is not None and key_states.shape[1] > sliding_window
+            _flash_supports_window_size
+            and sliding_window is not None
+            and key_states.shape[1] > sliding_window
         )
-    flash_kwargs = {"window_size": (sliding_window, sliding_window)} if use_sliding_windows else {}
+    flash_kwargs = (
+        {"window_size": (sliding_window, sliding_window)} if use_sliding_windows else {}
+    )
 
     try:
         if is_flash_attn_greater_or_equal("2.4.1"):
             if deterministic is None:
-                deterministic = os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
+                deterministic = (
+                    os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
+                )
             flash_kwargs["deterministic"] = deterministic
-    except:
-        # FIXME: is_flash_attn_greater_or_equal expects a packaging.version
-        # object for < 4.43
+    except AttributeError:
+        # FIXME: is_flash_attn_greater_or_equal expects a
+        # packaging.version object for < 4.43
         # - we just assume that this deterministic flag is not impt
         pass
 
@@ -160,6 +189,8 @@ def _flash_attention_forward_with_posids(
         **flash_kwargs,
     )
 
-    attn_output = attn_output.view(batch_size, -1, attn_output.size(-2), attn_output.size(-1))
+    attn_output = attn_output.view(
+        batch_size, -1, attn_output.size(-2), attn_output.size(-1)
+    )
 
     return attn_output

--- a/plugins/instruct-lab/src/fms_acceleration_ilab/ilab_utils.py
+++ b/plugins/instruct-lab/src/fms_acceleration_ilab/ilab_utils.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 import warnings
 from transformers import DefaultDataCollator, default_data_collator
 
+
 @dataclass
 class DataCollatorWithFlattening(DefaultDataCollator):
     """
@@ -51,4 +52,3 @@ class DataCollatorWithFlattening(DefaultDataCollator):
             else:
                 ret["labels"] += [-100] + feature["input_ids"][1:]
         return default_data_collator([ret], return_tensors)
-        


### PR DESCRIPTION
The PR #57 had a couple of mistakes that needed to be fix,  This is because of two things
1. the `flash_attention_forward` was moved out earlier
2. the actual padding free fix was done later, and is still not yet relaased (probably 4.44)

The strategy now is simple:
- if we can import DataCollatorWithFlattening successfully, means the padding free fix is done
- if we can import `_flash_attention_forward`, means the function has been seperated out

**Augmentation**
1. If padding free fix is done, then nothing to do, otherwise some patching is required
2. Patch the static or method `_flash_attention_forward` depending on version.

Some redesign is done, since `_flash_attention_forward` couild either be a method or function, then thje previous method to bind `_flash_attention_forward` by closure doesnt hold. So we need to install a method on the backbone to intercept the position ids, then modify `_flash_attention_forward` to be able to access the position ids, and bind them

Bad news is that once this is done properly, the speed dropped. **However, we verified that the speed is consistent when we upgrade transformers to latest main** which means our implementation is correct

```
{'loss': 0.8762, 'grad_norm': 69.0, 'learning_rate': 2e-05, 'epoch': 0.0}
{'loss': 0.9877, 'grad_norm': 29.40625, 'learning_rate': 1.7777777777777777e-05, 'epoch': 0.0}
{'loss': 1.0518, 'grad_norm': 38.90625, 'learning_rate': 1.555555555555556e-05, 'epoch': 0.0}
{'loss': 1.1429, 'grad_norm': 85.625, 'learning_rate': 1.3333333333333333e-05, 'epoch': 0.0}
{'loss': 1.0771, 'grad_norm': 22.890625, 'learning_rate': 1.1111111111111113e-05, 'epoch': 0.0}
{'loss': 0.9842, 'grad_norm': 33.5, 'learning_rate': 8.888888888888888e-06, 'epoch': 0.0}
{'loss': 2.4449, 'grad_norm': 19.9375, 'learning_rate': 6.666666666666667e-06, 'epoch': 0.01}
{'loss': 0.9717, 'grad_norm': 35.5625, 'learning_rate': 4.444444444444444e-06, 'epoch': 0.01}
{'loss': 0.8958, 'grad_norm': 25.203125, 'learning_rate': 2.222222222222222e-06, 'epoch': 0.01}
{'loss': 0.9145, 'grad_norm': 18.296875, 'learning_rate': 0.0, 'epoch': 0.01}
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [01:07<00:00,  1.41it/s]

Training completed. Do not forget to share your model on huggingface.co/models =)


{'train_runtime': 67.8947, 'train_samples_per_second': 5.891, 'train_steps_per_second': 1.473, 'train_tokens_per_second': 2029.615, 'train_loss': 1.1346958923339843, 'init_mem_cpu_alloc_delta': -14387679232, 'init_mem_gpu_alloc_delta': 14483611648, 'init_mem_cpu_peaked_delta': 14483382272, 'init_mem_gpu_peaked_delta': 0, 'train_mem_cpu_alloc_delta': 691978240, 'train_mem_gpu_alloc_delta': 28984245248, 'train_mem_cpu_peaked_delta': 0, 'train_mem_gpu_peaked_delta': 28990169600, 'before_init_mem_cpu': 15096680448, 'before_init_mem_gpu': 0, 'epoch': 0.01}

```