### PR TITLE
Rectify Missing Dataloader Preparation Call in PaddingFree Plugin Method

### DIFF
--- a/plugins/instruct-lab/src/fms_acceleration_ilab/framework_plugin_padding_free.py
+++ b/plugins/instruct-lab/src/fms_acceleration_ilab/framework_plugin_padding_free.py
@@ -207,7 +207,7 @@ class PaddingFreeAccelerationPlugin(AccelerationPlugin):
             # Replace the collate_fn in dataloader
             dataloader.collate_fn = DataCollatorWithFlattening()
 
-            return dataloader
+            return _old_prepare(dataloader)
 
         accelerator.prepare = MethodType(prepare, accelerator)
 


### PR DESCRIPTION
## Description

This PR fixes a missing dataloader preparation call in the PaddingFree Plugin that will cause num optimization steps in distributed experiments to be computed wrongly. 

With this fix, the relative performance improvement between `padded` vs `padding-free` approximately matches for 
-  FMS-Acceleration PaddingFree plugin, 24%
-  Natively supported padding free in Transformers, 26%

## ORCA Math 20K Subset - 1 Epoch
### [Transformers](https://github.com/huggingface/transformers/pull/31629)
| Model | DataProcess | Grad Accum | Per Device Batch Size | Num Devices | Time | Throughput (token/s) / device |
| -------- | ------- | ------- | ------- | ------- | ------- | ------- |
| Mistral-7B | Transformers Padded | 2 | 4 | 8 | 812 | 1216 |
| Mistral-7B | Transformers Native PaddingFree | 2 | 4 | 8 | 596 | 1658 |

### FMS-Acceleration Padding-Free Plugin
| Model | DataProcess | Grad Accum | Per Device Batch Size | Num Devices | Time | Throughput (token/s) / device |
| -------- | ------- | ------- | ------- | ------- | ------- | ------- |
| Mistral-7B | Padded-Longest | 2 | 4 | 8 | 818 | 1208 |
| Mistral-7B | PaddingFree Plugin | 2 | 4 | 8 | 621 | 1568 |
