### PR TITLE
Benchmarking: Add Response Field to Use Chat Templates Without Response Template

### DIFF
--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -166,6 +166,7 @@ class BenchmarkDataset:
         dataset_text_field: str = "output",
         chat_template: str = None,
         response_template: str = None,
+        response_field: str = None,
         additional_dataset_kwargs: Dict = {},
     ) -> None:
 
@@ -180,6 +181,7 @@ class BenchmarkDataset:
             "tokenize": tokenize,
             "input_field": input_field,
             "dataset_text_field": dataset_text_field,
+            "response_field": response_field,
             "chat_template": chat_template,
         }
         self.training_paths = {}  # cache to store the training paths


### PR DESCRIPTION
NOTE: this PR regards only data preparation for benches. It does not affect any plugin operation
- this only regards the flow where `chat_templates` are specified along with `tokenize: True`
When using chat templates, using response templates are error prone and trouble some, and it forces us to insert extranous
markers into the templates just for the sake of loss masking

For example below we add a `RESPONSE:` just to delineate the `prompt` from the `response`
```yaml
chat_template: |
    {%- for message in messages %}
    {{ message['prompt'] }} RESPONSE: {{ message ['response'] }}
    {%- endfor %}
tokenize: True
```

This PR allows us to do the following via the new `response_field` specification:
```yaml
chat_template: |
    {%- for message in messages %}
    {{ message['prompt'] }}
    {%- endfor %}
response_field: response
tokenize: True
```

This allows us to keep the `chat_template` clean and the code knows how to mask the loss