### PR TITLE
Create fused_CEloss.py

### DIFF
--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/fused_CEloss.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/fused_CEloss.py
@@ -1,0 +1,2 @@
+# placeholder for the fused CE loss from liger available at:
+# https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/fused_linear_cross_entropy.py


### PR DESCRIPTION
Create fused CE Loss from Liger kernels available at https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/fused_linear_cross_entropy.py