### PR TITLE
fixed bug in peft installation for gptqmodel

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -32,6 +32,18 @@ import torch
 # these parameters are to be patched for triton v2
 # consider making a map if patching more kernels
 PATCH_FOR_FSDP_TRITON_V2 = ["qweight", "qzeros"]
+PEFT_ALL_LINEAR = "all-linear"
+
+
+def requires_installation_on_all_linears(peft_config):
+    tm = peft_config.target_modules
+    assert isinstance(tm, (list, str)), "target modules can only be list or string"
+    if isinstance(tm, list):
+        if PEFT_ALL_LINEAR not in tm:
+            return False
+        assert len(tm) == 1, f"`{PEFT_ALL_LINEAR}` must exist alone in target modules"
+        return True
+    return tm == PEFT_ALL_LINEAR
 
 
 def build_patch_to_view_tensor_to_parameter_for_fsdp_gptq(

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -320,7 +320,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         model = get_gptq_peft_model(
             model,
             peft_config=peft_config,
-            auto_find_all_linears=peft_config.target_modules == PEFT_ALL_LINEAR,
+            auto_find_all_linears=(peft_config.target_modules == PEFT_ALL_LINEAR),
             train_mode=True,  # install adapaters for training
         )
         modifiable_args = (None,)  # return a None for peft_config

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -35,6 +35,8 @@ import torch.distributed
 # Local
 from .autogptq_utils import register_tensors_as_parameters_patch_rule
 
+PEFT_ALL_LINEAR = "all-linear"
+
 
 class AutoGPTQAccelerationPlugin(AccelerationPlugin):
 
@@ -318,7 +320,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         model = get_gptq_peft_model(
             model,
             peft_config=peft_config,
-            auto_find_all_linears=peft_config.target_modules is None,
+            auto_find_all_linears=peft_config.target_modules == PEFT_ALL_LINEAR,
             train_mode=True,  # install adapaters for training
         )
         modifiable_args = (None,)  # return a None for peft_config

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -33,9 +33,10 @@ import torch
 import torch.distributed
 
 # Local
-from .autogptq_utils import register_tensors_as_parameters_patch_rule
-
-PEFT_ALL_LINEAR = "all-linear"
+from .autogptq_utils import (
+    register_tensors_as_parameters_patch_rule,
+    requires_installation_on_all_linears,
+)
 
 
 class AutoGPTQAccelerationPlugin(AccelerationPlugin):
@@ -320,7 +321,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
         model = get_gptq_peft_model(
             model,
             peft_config=peft_config,
-            auto_find_all_linears=(peft_config.target_modules == PEFT_ALL_LINEAR),
+            auto_find_all_linears=requires_installation_on_all_linears(peft_config),
             train_mode=True,  # install adapaters for training
         )
         modifiable_args = (None,)  # return a None for peft_config

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/utils/peft.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/utils/peft.py
@@ -35,7 +35,7 @@ import torch
 
 # Local
 from ..models.base import BaseGPTQModel
-from ..nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as QuantLinearTriton
+from ..nn_modules.qlinear import BaseQuantLinear
 
 
 class GPTQLoraConfig(LoraConfig):
@@ -61,7 +61,7 @@ class GPTQLoraModel(LoraModel):
         lora_config: LoraConfig,
         adapter_name: str,
         target: torch.nn.Module,
-        target_cls: torch.nn.Module = QuantLinearTriton,
+        target_cls: torch.nn.Module = BaseQuantLinear,
         **kwargs,
     ):
         # if the base layer module matches a supported class, dispatch the lora linear
@@ -97,7 +97,7 @@ def find_all_linear_names(
         ignore.append(lm_head_name)
     results = set()
     for n, m in model.named_modules():
-        if isinstance(m, QuantLinearTriton):
+        if isinstance(m, BaseQuantLinear):
             res = n.split(".")[-1]
             if res not in ignore:
                 results.add(res)

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/utils/peft.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/utils/peft.py
@@ -92,12 +92,12 @@ def find_all_linear_names(
 ):
     if not ignore:
         ignore = []
-    lm_head_name = model.lm_head_name
+    lm_head_name = model.lm_head
     if ignore_lm_head and lm_head_name not in ignore:
         ignore.append(lm_head_name)
     results = set()
     for n, m in model.named_modules():
-        if isinstance(m, torch.nn.Linear):
+        if isinstance(m, QuantLinearTriton):
             res = n.split(".")[-1]
             if res not in ignore:
                 results.add(res)
@@ -127,6 +127,7 @@ def get_gptq_peft_model(
     adapter_name: str = "default",
     auto_find_all_linears: bool = True,
     train_mode: bool = False,
+    ignore_lm_head=True,
 ):
     if train_mode and not peft_config:
         raise ValueError("peft_config not specified when in train mode.")
@@ -142,7 +143,7 @@ def get_gptq_peft_model(
         if peft_type in [PeftType.LORA.value]:
             if auto_find_all_linears:
                 peft_config.target_modules = find_all_linear_names(
-                    model, ignore_lm_head=True
+                    model, ignore_lm_head=ignore_lm_head
                 )
             if peft_type == PeftType.LORA.value and not isinstance(
                 peft_config, GPTQLoraConfig


### PR DESCRIPTION
## Description

This is a fix for the gptq-peft plugin to follow the official peft implementation where specifying `target_modules='all-linear'` will install adapters on all linear layers. Note that [HF by default](https://github.com/huggingface/peft/blob/95b39642fb7e627464c81011c8c20d4676798cc9/src/peft/tuners/tuners_utils.py#L990) will not install adapters on `lm_head` for `all-linear`. This applies to both our locally maintained `gptqmodel` as well as the opensource `auto_gptq`.

 - Run with adapters installed on all linear modules `--target_modules 'all-linear`
```
python -m tuning.sft_trainer --model_name_or_path TheBloke/Mistral-7B-v0.1-GPTQ --packing False --max_seq_len 4096 --auto_gptq triton_v2 True --training_data_path orca/benchmark_outputs/data/cache_TheBloke_Mistral_7B_v0.1_GPTQ.json --use_flash_attn True --include_tokens_per_second True --num_train_epochs 1 --gradient_checkpointing True --evaluation_strategy no --save_strategy no --weight_decay 0.01 --warmup_steps 10 --adam_epsilon 1e-4 --lr_scheduler_type linear --logging_strategy steps --logging_steps 10 --learning_rate 2e-4 --fp16 True --torch_dtype float16 --peft_method lora --r 16 --lora_alpha 16 --lora_dropout 0.1 --target_modules all-linear --gradient_accumulation_steps 2 --per_device_train_batch_size 4 --output_dir tmp --skip_memory_metrics False
```
All linear layers except `lm_head` are installed with adapters and reflected in size of trainable parameters
```
***** Running training *****
  Num examples = 2,000
  Num Epochs = 1
  Instantaneous batch size per device = 4
  Total train batch size (w. parallel, distributed & accumulation) = 8
  Gradient Accumulation steps = 2
  Total optimization steps = 250
  Number of trainable parameters = 41,943,040
```

 - Run with specified target modules `--target_modules q_proj k_proj v_proj o_proj`, smaller trainable parameters are displayed.
```
python -m tuning.sft_trainer --model_name_or_path TheBloke/Mistral-7B-v0.1-GPTQ --packing False --max_seq_len 4096 --auto_gptq triton_v2 True --training_data_path orca/benchmark_outputs/data/cache_TheBloke_Mistral_7B_v0.1_GPTQ.json --use_flash_attn True --include_tokens_per_second True --num_train_epochs 1 --gradient_checkpointing True --evaluation_strategy no --save_strategy no --weight_decay 0.01 --warmup_steps 10 --adam_epsilon 1e-4 --lr_scheduler_type linear --logging_strategy steps --logging_steps 10 --learning_rate 2e-4 --fp16 True --torch_dtype float16 --peft_method lora --r 16 --lora_alpha 16 --lora_dropout 0.1 --target_modules q_proj k_proj v_proj o_proj --gradient_accumulation_steps 2 --per_device_train_batch_size 4 --output_dir tmp --skip_memory_metrics False
```
Smaller number of trainable parameters
```
***** Running training *****
  Num examples = 2,000
  Num Epochs = 1
  Instantaneous batch size per device = 4
  Total train batch size (w. parallel, distributed & accumulation) = 8
  Gradient Accumulation steps = 2
  Total optimization steps = 250
  Number of trainable parameters = 13,631,488
```