### PR TITLE
Fix Bug on Peft Config Check in AutoGPTQ Plugin

### DIFF
--- a/plugins/accelerated-peft/pyproject.toml
+++ b/plugins/accelerated-peft/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fms-acceleration-peft"
-version = '0.2.1'
+version = '0.2.0.dev'
 description = "FMS Acceleration for PeFT"
 authors = [
   {name = "Fabian Lim", email = "flim@sg.ibm.com"},

--- a/plugins/accelerated-peft/pyproject.toml
+++ b/plugins/accelerated-peft/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fms-acceleration-peft"
-version = '0.2.0.dev'
+version = '0.2.1'
 description = "FMS Acceleration for PeFT"
 authors = [
   {name = "Fabian Lim", email = "flim@sg.ibm.com"},

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -37,8 +37,10 @@ PEFT_ALL_LINEAR = "all-linear"
 
 def requires_installation_on_all_linears(peft_config):
     tm = peft_config.target_modules
-    assert isinstance(tm, (list, str)), "target modules can only be list or string"
-    if isinstance(tm, list):
+    assert isinstance(
+        tm, (list, set, str)
+    ), "target modules can only be list, set or string"
+    if isinstance(tm, (list, set)):
         if PEFT_ALL_LINEAR not in tm:
             return False
         assert len(tm) == 1, f"`{PEFT_ALL_LINEAR}` must exist alone in target modules"


### PR DESCRIPTION
## Description

This is a fix to address a mistake with a check on `target_modules` in peft_config. Target modules come in as a `set` and the assertion will be raised unnecessarily.

**mistake:**
`assert isinstance(tm, (list, str)), "target modules can only be list or string"`

**correction:**
`assert isinstance(tm, (list, set, str)), "target modules can only be list, set or string"`


Tested with alpaca on both `all-linear` and `q_proj k_proj v_proj o_proj`

`all-linear`
```
***** Running training *****
  Num examples = 2,754
  Num Epochs = 1
  Instantaneous batch size per device = 4
  Total train batch size (w. parallel, distributed & accumulation) = 4
  Gradient Accumulation steps = 1
  Total optimization steps = 100
  Number of trainable parameters = 41,943,040
```
`q_proj k_proj v_proj o_proj`
```
***** Running training *****
  Num examples = 2,754
  Num Epochs = 1
  Instantaneous batch size per device = 4
  Total train batch size (w. parallel, distributed & accumulation) = 4
  Gradient Accumulation steps = 1
  Total optimization steps = 100
  Number of trainable parameters = 13,631,488
```