### PR TITLE
Update Benchmarks and Documentation for GraniteCausalLM

### DIFF
--- a/plugins/accelerated-peft/requirements.txt
+++ b/plugins/accelerated-peft/requirements.txt
@@ -5,7 +5,10 @@
 accelerate >= 0.29
 
 # bitsandbytes for the BNB plugin
-bitsandbytes
+# - lower bound is because bnb is missing quant_state
+# - upper bound is because of segmentation faults
+# see https://github.com/foundation-model-stack/fms-acceleration/issues/17
+bitsandbytes >=0.41,<=0.43.3
 
 # Used to manage the thread limit in functions for converting old 
 # GPTQ models to new GPTQ model format that support symmetrical=False

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -116,27 +116,55 @@ class BNBAccelerationPlugin(AccelerationPlugin):
         except ValueError:
             world_size = 1  # pg not init
 
+        patched_is_local_dist_rank_0 = None
         if (
             world_size > 1
             and os.environ.get("ACCELERATE_USE_FSDP", "false").lower() == "true"
         ):
             config_kwargs["bnb_4bit_quant_storage"] = torch_dtype
 
+            # - of course assume that this package must exist, simply need the version
             _, _transformers_version = _is_package_available("transformers", return_version=True)
 
+            # this is a workaround that disables low_cpu_mem_mode for quant QLORA
+            # - this issue was introduced in https://github.com/huggingface/transformers/pull/33154
+            #   whereby the low_cpu_mem_mode was actually fixed. 
+            # - However fixing it causes some problems with the current impl.
+            # 1. For lora fused ops, the adapters cannot be managed by FSDP, as 
+            #  forwards are not called. This causes issue 2) in 
+            #  https://github.com/foundation-model-stack/fms-acceleration/issues/83
+            #  where the adapters are still sharded when passed in the fused-ops.
+            #  However, if low_cpu_mem_mode=True, then we NEED FSDP to intialize
+            # their state, which contradicts the above point.
+            # 
+            # 2. We have observed, 
+            # see https://github.com/foundation-model-stack/fms-acceleration/pull/86
+            # that low_cpu_mem_mode=True can cause torch distributed primitives
+            # to hang.
+            
             if _transformers_version >= "4.45":
+
+                # pylint: disable=import-outside-toplevel
                 from fms_acceleration.model_patcher import patch_target_module
+                import transformers.modeling_utils
 
                 def _truthy():
-                    return True
+                    return True # use this to always return True to is_local_dist_rank_0
 
+                # - we cannot use the model patcher and this needs to be called immediately below
+                #   at the model_loader
+                # - but we immediately revert the patch after loading
+                patched_is_local_dist_rank_0 = transformers.modeling_utils.is_local_dist_rank_0
                 patch_target_module(
                     "transformers.modeling_utils.is_local_dist_rank_0",
                     _truthy,
                 )
+
                 warnings.warn(
-                    "Disabling low_cpu_mem_mode as this will cause problems with "
-                    "the fused-ops-and-kernels package"
+                    "Disabling low_cpu_mem_mode in the BNBAccelerationPlugin as this may "
+                    "potentiall cause problems with: "
+                    "1. the fused-ops-and-kernels package, and, "
+                    "2. the syncing of FSDP modules across devices."
                 )
 
         elif world_size > 1:
@@ -170,6 +198,13 @@ class BNBAccelerationPlugin(AccelerationPlugin):
             low_cpu_mem_usage=low_cpu_mem_usage,
             attn_implementation=attn_implementation,
         )
+
+        if patched_is_local_dist_rank_0 is not None:
+            # replace it
+            patch_target_module(
+                "transformers.modeling_utils.is_local_dist_rank_0",
+                patched_is_local_dist_rank_0,
+            )
 
         return model
 

--- a/plugins/fused-ops-and-kernels/configs/fast_quantized_peft.yaml
+++ b/plugins/fused-ops-and-kernels/configs/fast_quantized_peft.yaml
@@ -24,7 +24,7 @@ peft:
       fast_loss: True
 
       # fast rms norm triton kernels
-      fast_rsm_layernorm: True
+      fast_rms_layernorm: True
 
       # fast RoPE embedding triton kernels
       fast_rope_embeddings: True

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/unsloth_lora/utils.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/unsloth_lora/utils.py
@@ -62,9 +62,10 @@ def get_lora_parameters(proj):
     # For DPO or disabled adapters
     base_layer = (proj.base_layer if hasattr(proj, "base_layer") else proj)
     W = base_layer.weight
+    bias = base_layer.bias if hasattr(base_layer, 'bias') else None
 
     if not hasattr(proj, "disable_adapters") or proj.disable_adapters or proj.merged:
-        return W, QUANT_STATE(W, base_layer), None, None, None, None
+        return W, QUANT_STATE(W, base_layer), None, None, None, None, None
     pass
 
     active_adapter = proj.active_adapters[0] if \
@@ -73,7 +74,7 @@ def get_lora_parameters(proj):
     B = proj.lora_B [active_adapter].weight
     s = proj.scaling[active_adapter]
     dropout = proj.lora_dropout[active_adapter] if hasattr(proj, "lora_dropout") else None
-    return W, QUANT_STATE(W, base_layer), A, B, s, dropout
+    return W, QUANT_STATE(W, base_layer), bias, A, B, s, dropout
 pass
 
 # modified by flim@sg.ibm.com

--- a/plugins/fused-ops-and-kernels/tests/test_foak_plugins.py
+++ b/plugins/fused-ops-and-kernels/tests/test_foak_plugins.py
@@ -35,6 +35,7 @@ CONFIG_PATH_AUTO_GPTQ_FOAK = os.path.join(
     DIRNAME, "../configs/fast_quantized_peft.yaml"
 )
 
+
 @pytest.mark.skip(reason="Installation logic has changed - test to be fixed in future.")
 def test_configure_gptq_foak_plugin():
     "test foak plugin loads correctly"

--- a/sample-configurations/accelerated-peft-autogptq-foak-padding-free-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-autogptq-foak-padding-free-sample-configuration.yaml
@@ -43,7 +43,10 @@ plugins:
         base_layer: auto_gptq
 
         # activate various unsloth optimizations
-        # NOTE: currently supports only all-or-nothing.
+        # there are two versions of the plugin
+        # - the FastKernel version supports individual kernels
+        # - the FastQuantized version is all-or-nothing
+
 
         # fused kernels for lora linear layers
         fused_lora: true
@@ -52,7 +55,7 @@ plugins:
         fast_loss: true
 
         # fast rms norm triton kernels
-        fast_rsm_layernorm: true
+        fast_rms_layernorm: true
 
         # fast RoPE embedding triton kernels
         fast_rope_embeddings: true

--- a/sample-configurations/accelerated-peft-autogptq-foak-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-autogptq-foak-sample-configuration.yaml
@@ -34,7 +34,10 @@ plugins:
         base_layer: auto_gptq
 
         # activate various unsloth optimizations
-        # NOTE: currently supports only all-or-nothing.
+        # there are two versions of the plugin
+        # - the FastKernel version supports individual kernels
+        # - the FastQuantized version is all-or-nothing
+
 
         # fused kernels for lora linear layers
         fused_lora: true
@@ -43,7 +46,7 @@ plugins:
         fast_loss: true
 
         # fast rms norm triton kernels
-        fast_rsm_layernorm: true
+        fast_rms_layernorm: true
 
         # fast RoPE embedding triton kernels
         fast_rope_embeddings: true

--- a/sample-configurations/accelerated-peft-bnb-nf4-foak-padding-free-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-bnb-nf4-foak-padding-free-sample-configuration.yaml
@@ -38,7 +38,10 @@ plugins:
         base_layer: bitsandbytes
 
         # activate various unsloth optimizations
-        # NOTE: currently supports only all-or-nothing.
+        # there are two versions of the plugin
+        # - the FastKernel version supports individual kernels
+        # - the FastQuantized version is all-or-nothing
+
 
         # fused kernels for lora linear layers
         fused_lora: true
@@ -47,7 +50,7 @@ plugins:
         fast_loss: true
 
         # fast rms norm triton kernels
-        fast_rsm_layernorm: true
+        fast_rms_layernorm: true
 
         # fast RoPE embedding triton kernels
         fast_rope_embeddings: true

--- a/sample-configurations/accelerated-peft-bnb-nf4-foak-sample-configuration.yaml
+++ b/sample-configurations/accelerated-peft-bnb-nf4-foak-sample-configuration.yaml
@@ -29,7 +29,10 @@ plugins:
         base_layer: bitsandbytes
 
         # activate various unsloth optimizations
-        # NOTE: currently supports only all-or-nothing.
+        # there are two versions of the plugin
+        # - the FastKernel version supports individual kernels
+        # - the FastQuantized version is all-or-nothing
+
 
         # fused kernels for lora linear layers
         fused_lora: true
@@ -38,7 +41,7 @@ plugins:
         fast_loss: true
 
         # fast rms norm triton kernels
-        fast_rsm_layernorm: true
+        fast_rms_layernorm: true
 
         # fast RoPE embedding triton kernels
         fast_rope_embeddings: true

--- a/sample-configurations/foak-fast-kernels-sample-configuration.yaml
+++ b/sample-configurations/foak-fast-kernels-sample-configuration.yaml
@@ -3,10 +3,9 @@
 # Each stanza incorporates various configurations for 
 # different fine-tuning / training tasks.
 plugins:
-  # Configurations to accelerate data packing/padding in training
   training:
 
-    fused_ops_and_kernels: 
+    fused_ops_and_kernels:
 
       # if under training stanza, then putting
       # base_layer and fused_lora will be a misnomer
@@ -22,10 +21,10 @@ plugins:
       # - the FastQuantized version is all-or-nothing
 
       # fast loss triton kernels
-      fast_loss: True
+      fast_loss: true
 
       # fast rms norm triton kernels
-      fast_rsm_layernorm: True
+      fast_rms_layernorm: true
 
       # fast RoPE embedding triton kernels
-      fast_rope_embeddings: True
+      fast_rope_embeddings: true

--- a/scripts/benchmarks/benchmark.py
+++ b/scripts/benchmarks/benchmark.py
@@ -1048,7 +1048,7 @@ if __name__ == "__main__":
         help="accelerate config file path",
     )
     parser.add_argument(
-        "--process_port", type=int, default=29500, help="accelerate process port"
+        "--process_port", type=int, default=29511, help="accelerate process port"
     )
     parser.add_argument(
         "--no_data_processing",

--- a/scripts/benchmarks/refs/a100_80gb_granite.csv
+++ b/scripts/benchmarks/refs/a100_80gb_granite.csv
@@ -1,0 +1,29 @@
+epoch,framework_config,learning_rate,lora_alpha,lora_dropout,mem_nvidia_mem_reserved,mem_peak_torch_mem_alloc_in_bytes,mem_torch_mem_alloc_in_bytes,model_name_or_path,num_gpus,output_dir,peft_method,per_device_train_batch_size,r,target_modules,torch_dtype,train_loss,train_runtime,train_samples_per_second,train_steps_per_second,train_tokens_per_second
+0.14,none,2e-5,,,47683.0,35134836736,21089537536,ibm/PowerLM-3b,1,benchmark_outputs3/exp_0/hf,,4,,,bfloat16,0.9698258590698242,322.7029,1.24,0.31,5077.116
+0.14,none,2e-5,,,43779.0,35198512128,28135299584,ibm/PowerLM-3b,2,benchmark_outputs3/exp_1/hf,,2,,,bfloat16,0.929816370010376,185.4019,2.157,0.539,4418.51
+0.29,none,2e-5,,,52927.0,47059390976,21089930752,ibm/PowerLM-3b,1,benchmark_outputs3/exp_2/hf,,8,,,bfloat16,0.9660552883148193,629.0534,1.272,0.159,5209.097
+0.29,none,2e-5,,,45698.0,35169178112,28129300992,ibm/PowerLM-3b,2,benchmark_outputs3/exp_3/hf,,4,,,bfloat16,0.9272240352630615,334.0146,2.395,0.299,4905.174
+0.14,foak-fast-kernels,2e-5,,,43333.0,35133716992,21088791040,ibm/PowerLM-3b,1,benchmark_outputs3/exp_4/hf,,4,,,bfloat16,0.9692397594451905,273.7817,1.461,0.365,5984.329
+0.14,foak-fast-kernels,2e-5,,,42204.0,35208045568,28144833024,ibm/PowerLM-3b,2,benchmark_outputs3/exp_5/hf,,2,,,bfloat16,0.9299186515808106,160.0673,2.499,0.625,5117.847
+0.29,foak-fast-kernels,2e-5,,,50077.0,40316365824,21089184256,ibm/PowerLM-3b,1,benchmark_outputs3/exp_6/hf,,8,,,bfloat16,0.9664452648162842,532.0588,1.504,0.188,6158.718
+0.29,foak-fast-kernels,2e-5,,,47155.0,35173639168,28114620928,ibm/PowerLM-3b,2,benchmark_outputs3/exp_7/hf,,4,,,bfloat16,0.9271490287780761,285.7146,2.8,0.35,5734.394
+0.14,none,2e-4,16,0.1,24383.0,20193463808,7183026688,ibm/PowerLM-3b,1,benchmark_outputs3/exp_8/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.0136762142181397,310.9178,1.287,0.322,5269.56
+0.14,none,2e-4,16,0.1,13849.0,10322532864,3625665536,ibm/PowerLM-3b,2,benchmark_outputs3/exp_9/hf,lora,2,16,q_proj k_proj v_proj o_proj,bfloat16,1.014874858856201,215.9738,1.852,0.463,3793.053
+0.29,none,2e-4,16,0.1,41093.0,33176473088,7183419904,ibm/PowerLM-3b,1,benchmark_outputs3/exp_10/hf,lora,8,16,q_proj k_proj v_proj o_proj,bfloat16,1.013114538192749,611.955,1.307,0.163,5354.642
+0.29,none,2e-4,16,0.1,22076.0,16835885568,3646137344,ibm/PowerLM-3b,2,benchmark_outputs3/exp_11/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.0142618751525878,332.7819,2.404,0.3,4923.344
+0.14,foak-fast-kernels,2e-4,16,0.1,21311.0,16897035264,7183026688,ibm/PowerLM-3b,1,benchmark_outputs3/exp_12/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.0154188919067382,262.241,1.525,0.381,6247.687
+0.14,foak-fast-kernels,2e-4,16,0.1,12241.0,8673304576,3624651776,ibm/PowerLM-3b,2,benchmark_outputs3/exp_13/hf,lora,2,16,q_proj k_proj v_proj o_proj,bfloat16,1.0135305118560791,195.6867,2.044,0.511,4186.284
+0.29,foak-fast-kernels,2e-4,16,0.1,34661.0,26585189376,7183419904,ibm/PowerLM-3b,1,benchmark_outputs3/exp_14/hf,lora,8,16,q_proj k_proj v_proj o_proj,bfloat16,1.0131592655181885,516.5368,1.549,0.194,6343.788
+0.29,foak-fast-kernels,2e-4,16,0.1,19014.0,13533374464,3640054784,ibm/PowerLM-3b,2,benchmark_outputs3/exp_15/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.011543436050415,290.371,2.755,0.344,5642.437
+0.14,baseline-peft-bnb,2e-4,16,0.1,23127.0,18174161920,2143825920,ibm/PowerLM-3b,1,benchmark_outputs3/exp_16/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.0207978439331056,391.2937,1.022,0.256,4187.137
+0.14,baseline-peft-bnb,2e-4,16,0.1,11254.0,7826759168,1129891840,ibm/PowerLM-3b,2,benchmark_outputs3/exp_17/hf,lora,2,16,q_proj k_proj v_proj o_proj,bfloat16,1.0213402462005616,220.9544,1.81,0.453,3707.553
+0.29,baseline-peft-bnb,2e-4,16,0.1,43327.0,34177070080,2144219136,ibm/PowerLM-3b,1,benchmark_outputs3/exp_18/hf,lora,8,16,q_proj k_proj v_proj o_proj,bfloat16,1.018005132675171,760.3699,1.052,0.132,4309.481
+0.29,baseline-peft-bnb,2e-4,16,0.1,19415.0,14319836672,1130088448,ibm/PowerLM-3b,2,benchmark_outputs3/exp_19/hf,lora,4,16,q_proj k_proj v_proj o_proj,bfloat16,1.0211043930053711,336.4976,2.377,0.297,4868.98
+0.14,accelerated-peft-bnb,2e-4,16,0.1,19379.0,15151677952,2141240832,ibm/PowerLM-3b,1,benchmark_outputs3/exp_20/hf,lora,4,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0230310726165772,296.6505,1.348,0.337,5522.998
+0.14,accelerated-peft-bnb,2e-4,16,0.1,11269.0,7826759168,1129891840,ibm/PowerLM-3b,2,benchmark_outputs3/exp_21/hf,lora,2,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0242974948883057,227.579,1.758,0.439,3599.629
+0.29,accelerated-peft-bnb,2e-4,16,0.1,35837.0,28134687232,2141634048,ibm/PowerLM-3b,1,benchmark_outputs3/exp_22/hf,lora,8,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.020608777999878,579.2578,1.381,0.173,5656.894
+0.29,accelerated-peft-bnb,2e-4,16,0.1,19406.0,14319836672,1130088448,ibm/PowerLM-3b,2,benchmark_outputs3/exp_23/hf,lora,4,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0224126720428466,334.7691,2.39,0.299,4894.12
+0.14,accelerated-peft-bnb-foak,2e-4,16,0.1,16347.0,11831656448,2141240832,ibm/PowerLM-3b,1,benchmark_outputs3/exp_24/hf,lora,4,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0216326427459717,247.0632,1.619,0.405,6631.502
+0.14,accelerated-peft-bnb-foak,2e-4,16,0.1,9705.0,6202137600,1129891840,ibm/PowerLM-3b,2,benchmark_outputs3/exp_25/hf,lora,2,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0239610195159912,137.0723,2.918,0.73,5976.408
+0.29,accelerated-peft-bnb-foak,2e-4,16,0.1,29777.0,21519810560,2141634048,ibm/PowerLM-3b,1,benchmark_outputs3/exp_26/hf,lora,8,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0218979930877685,480.7611,1.664,0.208,6815.859
+0.29,accelerated-peft-bnb-foak,2e-4,16,0.1,16454.0,11047001088,1130088448,ibm/PowerLM-3b,2,benchmark_outputs3/exp_27/hf,lora,4,16,q_proj k_proj v_proj o_proj c_attn,bfloat16,1.0228086185455323,252.2261,3.172,0.396,6495.76

--- a/scripts/benchmarks/refs/requirements_granite.txt
+++ b/scripts/benchmarks/refs/requirements_granite.txt
@@ -1,0 +1,86 @@
+accelerate @ git+https://github.com/huggingface/accelerate.git@4305033f8035defad0a87cd38e5c918e78510ba5
+aiohappyeyeballs==2.4.0
+aiohttp==3.10.6
+aiosignal==1.3.1
+async-timeout==4.0.3
+attrs==24.2.0
+bitsandbytes==0.43.3
+certifi==2024.8.30
+charset-normalizer==3.3.2
+contourpy==1.3.0
+cycler==0.12.1
+datasets==2.21.0
+dill==0.3.8
+docstring_parser==0.16
+einops==0.8.0
+filelock==3.16.1
+flash-attn==2.6.3
+-e git+https://github.com/foundation-model-stack/fms-acceleration.git@36c7fa7cb4ef413ddfbf55b75eb6135b369de038#egg=fms_acceleration&subdirectory=plugins/framework
+-e git+https://github.com/foundation-model-stack/fms-acceleration.git@36c7fa7cb4ef413ddfbf55b75eb6135b369de038#egg=fms_acceleration_aadp&subdirectory=plugins/attention-and-distributed-packing
+-e git+https://github.com/foundation-model-stack/fms-acceleration.git@36c7fa7cb4ef413ddfbf55b75eb6135b369de038#egg=fms_acceleration_foak&subdirectory=plugins/fused-ops-and-kernels
+-e git+https://github.com/foundation-model-stack/fms-acceleration.git@36c7fa7cb4ef413ddfbf55b75eb6135b369de038#egg=fms_acceleration_peft&subdirectory=plugins/accelerated-peft
+fms-hf-tuning @ git+https://github.com/foundation-model-stack/fms-hf-tuning.git@8676d0177c2f9436cf176342f38c3b5602f91751
+fonttools==4.54.1
+frozenlist==1.4.1
+fsspec==2024.6.1
+huggingface-hub==0.25.1
+idna==3.10
+Jinja2==3.1.4
+kiwisolver==1.4.7
+llvmlite==0.43.0
+markdown-it-py==3.0.0
+MarkupSafe==2.1.5
+matplotlib==3.9.2
+mdurl==0.1.2
+mpmath==1.3.0
+multidict==6.1.0
+multiprocess==0.70.16
+networkx==3.3
+numba==0.60.0
+numpy==1.26.4
+nvidia-cublas-cu12==12.1.3.1
+nvidia-cuda-cupti-cu12==12.1.105
+nvidia-cuda-nvrtc-cu12==12.1.105
+nvidia-cuda-runtime-cu12==12.1.105
+nvidia-cudnn-cu12==9.1.0.70
+nvidia-cufft-cu12==11.0.2.54
+nvidia-curand-cu12==10.3.2.106
+nvidia-cusolver-cu12==11.4.5.107
+nvidia-cusparse-cu12==12.1.0.106
+nvidia-nccl-cu12==2.20.5
+nvidia-nvjitlink-cu12==12.6.68
+nvidia-nvtx-cu12==12.1.105
+packaging==24.1
+pandas==2.2.3
+peft==0.12.0
+pillow==10.4.0
+protobuf==5.28.2
+psutil==6.0.0
+pyarrow==17.0.0
+Pygments==2.18.0
+pyparsing==3.1.4
+python-dateutil==2.9.0.post0
+pytz==2024.2
+PyYAML==6.0.2
+regex==2024.9.11
+requests==2.32.3
+rich==13.8.1
+safetensors==0.4.5
+sentencepiece==0.2.0
+shtab==1.7.1
+simpleeval==0.9.13
+six==1.16.0
+sympy==1.13.3
+threadpoolctl==3.5.0
+tokenizers==0.20.0
+torch==2.4.1
+tqdm==4.66.5
+transformers==4.45.0
+triton==3.0.0
+trl @ git+https://github.com/huggingface/trl.git@9af4734178d4436a8dc98a069042eedd2ccf178f
+typing_extensions==4.12.2
+tyro==0.8.11
+tzdata==2024.2
+urllib3==2.2.3
+xxhash==3.5.0
+yarl==1.12.1

--- a/scripts/benchmarks/scenarios-granite.yaml
+++ b/scripts/benchmarks/scenarios-granite.yaml
@@ -1,0 +1,112 @@
+# This file holds a list of scenarios to may be run.
+# - to limit to a number of scenarios, use the --run-only-scenarios flag.
+# - Each scenario will be run against a particular acceleration framework
+#   config, if the framework_config: key is specified.
+#   * a particular framework configuration
+# - the arguments tag will hold arguments to be passed to sft_trainer
+#   * the arguments are singular except for model_name_or_path which can handle
+#     multiple arguments.
+# - So anything that is critical for the scenario MUST be specified here 
+#   and not in the defaults, e.g. fp16
+
+# This stanza will be used in future to replace the custom processing functions in data_processing.py 
+# data_processing:
+#   dataset_name: yahma/alpaca-cleaned
+#   chat_template: |
+#     {%- for message in messages %}
+#         {% if message['input'] != '' %}
+#     Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
+
+#         {% else %}
+#     Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+#         {% endif %}
+#     ### Instruction:
+#     {{ message['instruction'] }}
+
+#         {% if message['input'] != '' %}
+#     ### Input:
+#     {{ message['input'] }}
+
+#         {% endif %}
+#     ### Response:
+#     {{ message['output'] + eos_token }}
+#     {% endfor %}
+#   tokenize: True
+
+
+scenarios:
+    -   name: full-finetuning
+        framework_config: 
+            - 
+            - foak-fast-kernels
+        arguments:
+            learning_rate: 2e-5
+            model_name_or_path: 
+                - 'ibm/PowerLM-3b'
+            torch_dtype: bfloat16
+            bf16: True
+
+    -   name: standard-peft
+        framework_config: 
+            - 
+            - foak-fast-kernels
+        arguments:
+            bf16: True
+            learning_rate: 2e-4
+            torch_dtype: bfloat16
+            peft_method: lora
+            r: 16
+            lora_alpha: 16
+            lora_dropout: 0.1
+            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+            model_name_or_path: 
+                - 'ibm/PowerLM-3b'
+
+    -   name: baseline-peft-bnb
+        framework_config: 
+            - baseline-peft-bnb
+        arguments:
+            bf16: True
+            learning_rate: 2e-4
+            torch_dtype: bfloat16
+            peft_method: lora
+            r: 16
+            lora_alpha: 16
+            lora_dropout: 0.1
+            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+            model_name_or_path: 
+                - 'ibm/PowerLM-3b'
+
+    -   name: accelerated-peft-bnb
+        framework_config: 
+            - accelerated-peft-bnb
+            - accelerated-peft-bnb-foak
+        arguments:
+            bf16: True
+            learning_rate: 2e-4
+            torch_dtype: bfloat16
+            peft_method: lora
+            r: 16
+            lora_alpha: 16
+            lora_dropout: 0.1
+            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj", "c_attn"]
+            model_name_or_path: 
+                - 'ibm/PowerLM-3b'
+
+    # when ready to add this to bench uncomment
+    # -   name: accelerated-peft-gptq
+    #     framework_config: 
+    #         - accelerated-peft-autogptq
+    #         - accelerated-peft-autogptq-foak
+    #     arguments:
+    #         learning_rate: 2e-4
+    #         fp16: True # running gptq-lora in float16 is more performant, see issue
+    #         torch_dtype: float16 # https://github.com/foundation-model-stack/fms-acceleration/issues/84
+    #         peft_method: lora
+    #         r: 16
+    #         lora_alpha: 16
+    #         lora_dropout: 0.1
+    #         target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
+    #         model_name_or_path: 
+    #             - 'ibm/PowerLM-3b'

--- a/scripts/benchmarks/scenarios.yaml
+++ b/scripts/benchmarks/scenarios.yaml
@@ -43,7 +43,7 @@ scenarios:
         arguments:
             learning_rate: 2e-5
             model_name_or_path: 
-                # - 'ibm/PowerLM-3b'
+                - 'ibm/PowerLM-3b'
                 - 'bigcode/gpt_bigcode-santacoder'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
@@ -65,6 +65,7 @@ scenarios:
             lora_dropout: 0.1
             target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
             model_name_or_path: 
+                - 'ibm/PowerLM-3b'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
                 - 'NousResearch/Llama-2-70b-hf'
@@ -100,7 +101,7 @@ scenarios:
             lora_dropout: 0.1
             target_modules: ["q_proj", "k_proj", "v_proj", "o_proj", "c_attn"]
             model_name_or_path: 
-                # - 'ibm/PowerLM-3b'
+                - 'ibm/PowerLM-3b'
                 - 'bigcode/gpt_bigcode-santacoder'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'

--- a/scripts/generate_sample_configurations.py
+++ b/scripts/generate_sample_configurations.py
@@ -192,7 +192,7 @@ COMBINATIONS = [
     ("accelerated-peft-autogptq-foak-padding-free", (KEY_AADP_PADDING_FREE,KEY_AUTO_GPTQ, KEY_AUTO_GPTQ_FOAK)),
     ("accelerated-peft-bnb-nf4-foak-padding-free", (KEY_AADP_PADDING_FREE,KEY_BNB_NF4, KEY_BNB_NF4_FOAK)),
     ("aadp-padding-free-multipack", (KEY_AADP_PADDING_FREE, KEY_AADP_MULTIPACK)),
-    ("foak-fast-kernels", (KEY_FAST_KERNELS))
+    ("foak-fast-kernels", (KEY_FAST_KERNELS,))
 ]
 
 

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -125,6 +125,15 @@ PYTHONPATH=. \
     --result_file $BENCH_RESULT_FILE \
     --keep_columns \
         'torch_dtype' \
+	    "framework_config" \
+		"peft_method" \
+     	"model_name_or_path" \
+		"num_gpus" \
+		"per_device_train_batch_size" \
+		"mem_nvidia_mem_reserved" \
+	    "mem_peak_torch_mem_alloc_in_bytes" \
+		"mem_torch_mem_alloc_in_bytes" \
+		"train_tokens_per_second" \
     --remove_columns \
         'before_init_mem_cpu' \
         'before_init_mem_gpu' \


### PR DESCRIPTION
In this PR we update the benchmarks for `GraniteCausalLM`
- in addition, the [README.md](https://github.com/foundation-model-stack/fms-acceleration/blob/granite-foak/plugins/fused-ops-and-kernels/README.md#adding-support-for-a-new-model)  is also updated to describe how a new model can be added in the future
- NOTE: we did not update the GPTQ results in the bench. will do this possibly at a later time.

Note this PR requires the following dependency updates
- `transformers>=4.45`: for `GraniteCausalLM`
- `accelerate>=0.34.1`:  required for `transformers>=4.45` if `GraniteCausalLM` is needed.
- `trl > 0.11.1`: when using baseline bnb, requires this fix for a bug that was introduced in `transformers==4.45` https://github.com/huggingface/trl/pull/2089
- `bitsandtbyes==0.43.3`: it seems that the later versions give segmentation fault errors

Known issues with quant peft
- [x] single GPU w/o FOAK 
- [x] single GPU w FOAK ->  ~fused lora dequant problem~ (this is an issue with the compiled binaries in bitsandbytes 0.43.3, that is not compatible with maybe the CUDA toolkit or torch version)
- [x] multi GPU w/o FOAK -> ~rank 1 stuck at prepare_model~ (this is resolved by disabling `low_cpu_mem_mode`)
- [x] multi GPU w FOAK -> ~meta device problem~ (see 2 in #83) (this is resolved by disabling `low_cpu_mem_mode`)
- [x] bad loss with BNB+FOAK -> (resolved by updating lora fused ops to support bias)

## Performance

Overall impressive improvements with kernels.


**FULL FT**
![image](https://github.com/user-attachments/assets/05e701c7-af47-46ba-a8d2-7d9ff9532db9)

**PEFT**
![image](https://github.com/user-attachments/assets/c1b7d4d6-35e7-455c-b8dc-83ea2c70a00b)


**Quantized Peft (BNB)**
![image](https://github.com/user-attachments/assets/181d8acc-0276-4d60-bbb3-68761b02393f)
