### PR TITLE
Fixes to Accelerated Peft

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -35,11 +35,28 @@ PATCH_FOR_FSDP_TRITON_V2 = ["qweight", "qzeros"]
 PEFT_ALL_LINEAR = "all-linear"
 
 
-def requires_installation_on_all_linears(peft_config):
+def requires_installation_on_all_linears(peft_config, model_type: str = None):
     tm = peft_config.target_modules
+
+    if tm is None:
+        try:
+            # Third Party
+            # pylint: disable=import-outside-toplevel
+            from peft.utils.constants import (
+                TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING,
+            )
+
+            tm = TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_type]
+        except (ImportError, IndexError) as e:
+            raise ValueError(
+                "target modules not specified and unable to determine default "
+                f"for given model type {model_type}."
+            ) from e
+
+        # replace with some defaults
     assert isinstance(
         tm, (list, set, str)
-    ), "target modules can only be list, set or string"
+    ), "if provided, target modules can only be list, set or string"
     if isinstance(tm, (list, set)):
         if PEFT_ALL_LINEAR not in tm:
             return False

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/autogptq_utils.py
@@ -47,7 +47,7 @@ def requires_installation_on_all_linears(peft_config, model_type: str = None):
             )
 
             tm = TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_type]
-        except (ImportError, IndexError) as e:
+        except (ImportError, KeyError) as e:
             raise ValueError(
                 "target modules not specified and unable to determine default "
                 f"for given model type {model_type}."

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -319,10 +319,18 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             )
 
         # Install GPTQ adapters using the AutoGPTQ package (with the above patches)
+        # - try to get a model config to auto determine the layers that can be helpful
+        #
+        model_type = (
+            model.config.model_type if hasattr(model.config, "model_type") else None
+        )
         model = get_gptq_peft_model(
             model,
             peft_config=peft_config,
-            auto_find_all_linears=requires_installation_on_all_linears(peft_config),
+            auto_find_all_linears=requires_installation_on_all_linears(
+                peft_config,
+                model_type=model_type,
+            ),
             train_mode=True,  # install adapaters for training
         )
 

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -144,8 +144,7 @@ class BNBAccelerationPlugin(AccelerationPlugin):
             # that low_cpu_mem_mode=True can cause torch distributed primitives
             # to hang.
 
-            # if _transformers_version >= "4.45":
-            if False:
+            if _transformers_version >= "4.45":
 
                 # pylint: disable=import-outside-toplevel
                 # Third Party

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_bnb.py
@@ -144,7 +144,8 @@ class BNBAccelerationPlugin(AccelerationPlugin):
             # that low_cpu_mem_mode=True can cause torch distributed primitives
             # to hang.
 
-            if _transformers_version >= "4.45":
+            # if _transformers_version >= "4.45":
+            if False:
 
                 # pylint: disable=import-outside-toplevel
                 # Third Party

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/models/base.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/gptqmodel/models/base.py
@@ -1114,8 +1114,6 @@ class BaseGPTQModel(nn.Module):
                 # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
                 checkpoint=model_save_name,
                 device_map=device_map,
-                offload_state_dict=True,
-                offload_buffers=True,
             )
             # validate sym=False v1 loading needs to be protected for models produced with new v2 format codebase
             if (
@@ -1143,8 +1141,6 @@ class BaseGPTQModel(nn.Module):
                 dtype=torch_dtype,  # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
                 checkpoint=model_save_name,
                 device_map=device_map,
-                offload_state_dict=True,
-                offload_buffers=True,
             )
         # TODO: Why are we using this custom function and not dispatch_model?
         model = simple_dispatch_model(model, device_map)

--- a/scripts/benchmarks/scenarios-granite.yaml
+++ b/scripts/benchmarks/scenarios-granite.yaml
@@ -90,7 +90,7 @@ scenarios:
             r: 16
             lora_alpha: 16
             lora_dropout: 0.1
-            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj", "c_attn"]
+            target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
             model_name_or_path: 
                 - 'ibm/PowerLM-3b'
 

--- a/scripts/benchmarks/scenarios.yaml
+++ b/scripts/benchmarks/scenarios.yaml
@@ -43,7 +43,6 @@ scenarios:
         arguments:
             learning_rate: 2e-5
             model_name_or_path: 
-                - 'ibm/PowerLM-3b'
                 - 'bigcode/gpt_bigcode-santacoder'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
@@ -65,7 +64,6 @@ scenarios:
             lora_dropout: 0.1
             target_modules: ["q_proj", "k_proj", "v_proj", "o_proj"]
             model_name_or_path: 
-                - 'ibm/PowerLM-3b'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'
                 - 'NousResearch/Llama-2-70b-hf'
@@ -101,7 +99,6 @@ scenarios:
             lora_dropout: 0.1
             target_modules: ["q_proj", "k_proj", "v_proj", "o_proj", "c_attn"]
             model_name_or_path: 
-                - 'ibm/PowerLM-3b'
                 - 'bigcode/gpt_bigcode-santacoder'
                 - 'mistralai/Mistral-7B-v0.1'
                 - 'mistralai/Mixtral-8x7B-Instruct-v0.1'


### PR DESCRIPTION
This PR provides two fixes
1. fallback to target module defaults. To keep in line with regular HF behavior, we fallback to HF default target modules if `--target_modules` happen to be omitted from the `peft_config`
2. disabling the gptq v1 to v2 conversion: we revert back to default HF behavior and disable offloading. Upon reviewing the [accelerate.load_checkpoint_in_model](https://github.com/huggingface/accelerate/blob/127818fc27ebe5cb236357fff59ff1748326d643/src/accelerate/utils/modeling.py#L1611) i know start to feel the offloading may not be needed moving forward. The main purpose of that function is to read the (sharded) checkpoint and load it into the model (on the CPU, since low_cpu_mem_mode is not working for GPTQ). I think the proper way forward is to get `low_cpu_mem_mode` working for GPTQ, and not worry about offloading the state dict (as it is a hack in itself).

However do note that for `low_cpu_mem_mode` we have observed some problems in the BNB case for certain models (e.g., `GraniteCausalForLM`), see https://github.com/foundation-model-stack/fms-acceleration/issues/83