### PR TITLE
Apply Retie Weights Fix Regardless of Transformers and TRL version for AutoGPTQ

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -356,38 +356,29 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             accelerator is not None
             and getattr(accelerator.state, "fsdp_plugin", None) is not None
         ):
-            _, _transformers_version = _is_package_available(
-                "transformers", return_version=True
-            )
-            _trl_installed, _trl_version = _is_package_available(
-                "trl", return_version=True
-            )
 
-            # the meta device fix for quantized models is since this transformers version
-            # or if trl is installed then its only for this version
-            if _transformers_version >= "4.45" and (
-                not _trl_installed or (_trl_installed and _trl_version >= "0.12")
-            ):
-                # guarded
-                # NOTE: replace this later with a more specific accelerate version check
-                try:
-                    # Third Party
-                    # pylint: disable=import-outside-toplevel
-                    from torch.distributed.utils import ensure_weights_retied
+            # for autogptq we will install the fix regardless of transformers or 
+            # trl version, because those fixes were only for BNB. Here we control
+            # our own model loading
+            # NOTE: guard this later with a more specific accelerate version check
+            try:
+                # Third Party
+                # pylint: disable=import-outside-toplevel
+                from torch.distributed.utils import ensure_weights_retied
 
-                    # then its handled internally and there is nothing to do
-                except ImportError:
-                    # need to use our internal version
-                    # Local
-                    from .fsdp_utils import (  # pylint: disable=import-outside-toplevel
-                        ensure_weights_retied,
-                    )
+                # then its handled internally and there is nothing to do
+            except ImportError:
+                # need to use our internal version
+                # Local
+                from .fsdp_utils import (  # pylint: disable=import-outside-toplevel
+                    ensure_weights_retied,
+                )
 
-                    accelerator.state.fsdp_plugin.param_init_fn = ensure_weights_retied(
-                        accelerator.state.fsdp_plugin.param_init_fn,
-                        model.get_base_model(),
-                        accelerator.device,
-                    )
+                accelerator.state.fsdp_plugin.param_init_fn = ensure_weights_retied(
+                    accelerator.state.fsdp_plugin.param_init_fn,
+                    model.get_base_model(),
+                    accelerator.device,
+                )
         return callbacks
 
 

--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -357,7 +357,7 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
             and getattr(accelerator.state, "fsdp_plugin", None) is not None
         ):
 
-            # for autogptq we will install the fix regardless of transformers or 
+            # for autogptq we will install the fix regardless of transformers or
             # trl version, because those fixes were only for BNB. Here we control
             # our own model loading
             # NOTE: guard this later with a more specific accelerate version check


### PR DESCRIPTION
In the previous PR #90 we applied a fix for retying the weights, however it was incorrectly done for AutoGPTQ. 
- for BNB, we apply the fix only for certain transformers and trl versions, because the `meta` device `low_cpu_mem_mode` was enabled only for those versions
- however for GPTQ, this is not the case, since we handle `low_cpu_mem_mode` seperately from HF. Hence the fix must be applied immediately. This PR fixes that.

 