### PR TITLE
Fix Issue with Resizing Parameters on the Meta Device in Low CPU Mem Mode

### DIFF
--- a/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
+++ b/plugins/accelerated-peft/src/fms_acceleration_peft/framework_plugin_autogptq.py
@@ -38,6 +38,7 @@ from .autogptq_utils import (
     register_tensors_as_parameters_patch_rule,
     requires_installation_on_all_linears,
 )
+from .fsdp_utils import put_selected_meta_tensors_on_cpu
 
 
 class AutoGPTQAccelerationPlugin(AccelerationPlugin):
@@ -218,6 +219,11 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
 
             # replace
             AutoModelForCausalLM.from_config = _old_from_config
+
+            # in low_cpu_mem_mode, if certain tensors like embeddings
+            # are in the meta device, then certain operations like
+            # embedding resizing will fail
+            put_selected_meta_tensors_on_cpu(model)
 
         # AutoGPTQ does not set the torch_dtype of the model carefully
         model.config.torch_dtype = torch_dtype


### PR DESCRIPTION
Due to the recent Low CPU Memory Fixes #90 that happened for `transformers >= 0.45`, this is a remaining issue. 

If the parameters are in the `meta` device, then they will not be able to be resized. This will cause a problem in `fms-hf-tuning`, where the embedding table is resized based on the number of new tokens.

This PR is a fix to move selected parameters into the CPU device; this is caused by the incosistentcy of the fix in https://github.com/huggingface/transformers/pull/33154 for the QLoRA and non-quantized cases, see below. We adopt a solution that is in between.
- for QLoRA, all parameters are left on the `meta` device
- for full finetuning, the parameters are initialised using `empty` and moved to the `cpu` device.

The former is the correct logic, but it will cause problems when resizing embeddings. The later is not has no resizing problems, but is not ideal because again large CPU memory is consumed, defeating the purpose of `low_cpu_mem_mode`


**Additional Fix**

This PR also fixes the reduce_grad hook that was bugged in #90 