### PR TITLE
Fix Dropout in Fused LoRA Operations

### DIFF
--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/framework_plugin_fast_quantized_peft.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/framework_plugin_fast_quantized_peft.py
@@ -25,6 +25,7 @@ from transformers.modeling_utils import is_fsdp_enabled
 import torch
 import torch.distributed as dist
 
+
 # consider moving this somewhere else later
 def lora_adapters_switch_ddp_from_fsdp(modules, fsdp_plugin):
     """
@@ -56,7 +57,7 @@ def lora_adapters_switch_ddp_from_fsdp(modules, fsdp_plugin):
         if not A.weight.is_cuda:
             value = A.weight
 
-            if is_fsdp_enabled() and value.device == torch.device('meta'):
+            if is_fsdp_enabled() and value.device == torch.device("meta"):
                 # if low_cpu_mem_mode
                 value = torch.empty(*value.size(), dtype=value.dtype)
 
@@ -68,7 +69,7 @@ def lora_adapters_switch_ddp_from_fsdp(modules, fsdp_plugin):
         if not B.weight.is_cuda:
             value = B.weight
 
-            if is_fsdp_enabled() and value.device == torch.device('meta'):
+            if is_fsdp_enabled() and value.device == torch.device("meta"):
                 value = torch.empty(*value.size(), dtype=value.dtype)
 
             set_module_tensor_to_device(B, "weight", "cuda", value)
@@ -80,6 +81,7 @@ def lora_adapters_switch_ddp_from_fsdp(modules, fsdp_plugin):
         # - this has to be done after all weight replacement happens
         A.weight.register_hook(_all_reduce_hook)
         B.weight.register_hook(_all_reduce_hook)
+
 
 def register_foak_model_patch_rules(base_type):
     # Third Party

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/unsloth_lora/utils.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/fused_ops/unsloth_lora/utils.py
@@ -260,10 +260,16 @@ def matmul_lora(X, W, W_quant, A, B, s, out = None, dropout=None):
     if A is not None:
         # LoRA is enabled
         if dropout is not None:
-            # in order to return the dropped out X to the 
-            # top level, we save it on the dropout module
-            X = dropout(X)
-            dropout.X = X
+            if isinstance(dropout, torch.Tensor):
+                X *= dropout
+            elif isinstance(dropout, torch.nn.Module):
+                # in order to return the dropped out X to the 
+                # top level, we save it on the dropout module
+                X = dropout(X)
+                dropout.X = X
+            else:
+                raise NotImplementedError("dropout must be a tensor or module.")
+
         A, B = A.t(), B.t()
         out += (X @ A.to(dtype)) @ (s * B.to(dtype))
     pass

--- a/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
+++ b/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
@@ -240,12 +240,21 @@ def loaded_models(device: torch.device = "cuda"):
     class TrainArgs:
         gradient_checkpointing = False
         gradient_checkpointing_kwargs = {}
+        fp16 = False
+        bf16 = False
 
-    args = TrainArgs()
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
 
     all_models = {}
     for dtype in DTYPES:
         for base_type in [BNB, GPTQ]:
+
+            args = TrainArgs(
+                fp16=dtype==FLOAT16
+            )
+
             for r, lora_alpha in LORA_PARAMS:
                 model_name, _, target_modules = TEST_MODELS[base_type]
                 peft_config = LoraConfig(
@@ -389,8 +398,8 @@ def test_adapter_gradients_match_with_attention_layer(
 
 
 @pytest.mark.skipif(
-    not _is_package_available("bitsandbytes") or not _is_package_available("auto_gptq"),
-    reason="Only runs if both bitsandbytes and auto_gptq are installed",
+    not _is_package_available("bitsandbytes"),
+    reason="Only runs if both bitsandbytes",
 )
 def test_adapter_gradients_match_with_model(
     model_inputs, loaded_models, dropout_masks  # pylint: disable=redefined-outer-name

--- a/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
+++ b/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from itertools import product
 
 # Third Party
-from fms_acceleration.model_patcher import patch_model
+from fms_acceleration.model_patcher import patch_model, ModelPatcher
+from fms_acceleration.utils.test_utils import instantiate_model_patcher
 from peft import LoraConfig
 from transformers import AutoConfig
 from transformers.models.llama.modeling_llama import LlamaAttention
@@ -43,6 +44,7 @@ TEST_MODELS = {
         ["q_proj", "k_proj", "v_proj", "o_proj"],
     ),
 }
+
 
 ADAPTER_NAME = "default"
 
@@ -248,11 +250,12 @@ def loaded_models(device: torch.device = "cuda"):
 
     all_models = {}
     for dtype in DTYPES:
-        for base_type in [BNB, GPTQ]:
 
-            args = TrainArgs(
-                fp16=(dtype==FLOAT16)
-            )
+        args = TrainArgs(
+            fp16=(dtype==FLOAT16)
+        )
+
+        for base_type in [BNB, GPTQ]:
 
             for r, lora_alpha in LORA_PARAMS:
                 model_name, _, target_modules = TEST_MODELS[base_type]
@@ -281,13 +284,6 @@ def loaded_models(device: torch.device = "cuda"):
                     )
 
     return all_models
-
-
-def prepare_foak(attn_module, base_type):
-    _model = patch_model(attn_module, base_type=base_type)
-    # print(patch_model_summary())
-    return _model
-
 
 def run_model(
     model,
@@ -334,6 +330,20 @@ def get_attention_lora_grads(model, target_modules):
         raise ValueError("cannot find adapter grads")
     return adapter_grads
 
+# helper function to register the fused ops
+def register_fused_ops_rules(base_type: str):
+
+    # Local
+    # add more models if needed later
+    from fms_acceleration_foak.models import (  # pylint: disable=import-outside-toplevel
+        llama,
+    )
+
+    for r in [
+        *llama.get_mp_rules(base_type)
+    ]:
+        if any(r.rule_id.endswith(x) for x in {"qkvo", "mlp"}):
+            ModelPatcher.register(r)
 
 # -------------------------- TESTS ----------------------------------
 
@@ -372,28 +382,46 @@ def test_adapter_gradients_match_with_attention_layer(
                     attn = attention_layers[(base_type, r, lora_alpha, dtype)]
                     DummyDropout.dropout_mask = dropout_masks[(sl, hd, d)]
 
-                    # prepare models
-                    without_foak = deepcopy(attn)
-                    with_foak = prepare_foak(deepcopy(attn), base_type)
+                    X_without = X.clone().detach().requires_grad_()
+                    X_with = X.clone().detach().requires_grad_()
 
-                    # run the models and get the loss and gradients
-                    loss_unpatched = run_model(without_foak, dtype, X, **_kwargs)
-                    loss_patched = run_model(with_foak, dtype, X, **_kwargs)
+                    # instantiate the sigleton model patcher
+                    with instantiate_model_patcher():
 
-                    # compute outputs
-                    assert (
-                        loss_unpatched - loss_patched
-                    ).abs() < LOSS_TOL, "Loss after foak patch do not match"
+                        # register the fused op rules
+                        register_fused_ops_rules(base_type)
 
-                    grads_unpatched = get_attention_lora_grads(
-                        without_foak, target_modules
-                    )
-                    grads_patched = get_attention_lora_grads(with_foak, target_modules)
+                        # prepare models
+                        without_foak = deepcopy(attn)
+                        with_foak = patch_model(deepcopy(attn))
 
-                    for x, y in zip(grads_unpatched, grads_patched):
-                        assert torch.allclose(
-                            x, y, atol=ALLCLOSE_ATOL, rtol=ALLCLOSE_RTOL
-                        ), "Gradients don't match after foak patch"
+                        # run the models and get the loss and gradients
+                        loss_unpatched = run_model(without_foak, dtype, X_without, **_kwargs)
+                        loss_patched = run_model(with_foak, dtype, X_with, **_kwargs)
+
+                        # check the model has been patched
+                        assert len(ModelPatcher.history) > 0, "Fused ops did not correctly patch"
+
+                        # compute outputs
+                        assert (
+                            loss_unpatched - loss_patched
+                        ).abs() < LOSS_TOL, "Loss after foak patch do not match"
+
+                        # check input gradients
+                        torch.allclose(
+                            X_without.grad, 
+                            X_with.grad, atol=ALLCLOSE_ATOL, rtol=ALLCLOSE_RTOL
+                        )
+
+                        grads_unpatched = get_attention_lora_grads(
+                            without_foak, target_modules
+                        )
+                        grads_patched = get_attention_lora_grads(with_foak, target_modules)
+
+                        for x, y in zip(grads_unpatched, grads_patched):
+                            assert torch.allclose(
+                                x, y, atol=ALLCLOSE_ATOL, rtol=ALLCLOSE_RTOL
+                            ), "Gradients don't match after foak patch"
 
 
 @pytest.mark.skipif(
@@ -425,31 +453,40 @@ def test_adapter_gradients_match_with_model(
                     model = loaded_models[(base_type, r, lora_alpha, dtype)]
                     DummyDropout.dropout_mask = dropout_masks[(sl, hd, d)]
 
-                    # prepare models
-                    without_foak = deepcopy(model)
-                    with_foak = prepare_foak(deepcopy(model), base_type)
+                    # instantiate the sigleton model patcher
+                    with instantiate_model_patcher():
 
-                    # run the models and get the loss and gradients
-                    loss_unpatched = run_model(
-                        without_foak, dtype, input_ids, **_kwargs
-                    )
-                    loss_patched = run_model(with_foak, dtype, input_ids, **_kwargs)
+                        # register the fused op rules
+                        register_fused_ops_rules(base_type)
 
-                    # compute outputs
-                    assert (
-                        loss_unpatched - loss_patched
-                    ).abs() < LOSS_TOL, "Loss after foak patch do not match"
+                        # prepare models
+                        without_foak = deepcopy(model)
+                        with_foak = patch_model(deepcopy(model))
 
-                    for _without, _with in zip(
-                        get_modules_with_class(without_foak, attn_cls),
-                        get_modules_with_class(with_foak, attn_cls),
-                    ):
-                        grads_unpatched = get_attention_lora_grads(
-                            _without, target_modules
+                        # check the model has been patched
+                        assert len(ModelPatcher.history) > 0, "Fused ops did not correctly patch"
+
+                        # run the models and get the loss and gradients
+                        loss_unpatched = run_model(
+                            without_foak, dtype, input_ids, **_kwargs
                         )
-                        grads_patched = get_attention_lora_grads(_with, target_modules)
+                        loss_patched = run_model(with_foak, dtype, input_ids, **_kwargs)
 
-                    for x, y in zip(grads_unpatched, grads_patched):
-                        assert torch.allclose(
-                            x, y, atol=ALLCLOSE_ATOL, rtol=ALLCLOSE_RTOL
-                        ), "Gradients don't match after foak patch"
+                        # compute outputs
+                        assert (
+                            loss_unpatched - loss_patched
+                        ).abs() < LOSS_TOL, "Loss after foak patch do not match"
+
+                        for _without, _with in zip(
+                            get_modules_with_class(without_foak, attn_cls),
+                            get_modules_with_class(with_foak, attn_cls),
+                        ):
+                            grads_unpatched = get_attention_lora_grads(
+                                _without, target_modules
+                            )
+                            grads_patched = get_attention_lora_grads(_with, target_modules)
+
+                        for x, y in zip(grads_unpatched, grads_patched):
+                            assert torch.allclose(
+                                x, y, atol=ALLCLOSE_ATOL, rtol=ALLCLOSE_RTOL
+                            ), "Gradients don't match after foak patch"

--- a/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
+++ b/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
@@ -8,8 +8,10 @@ from peft import LoraConfig
 from transformers import AutoConfig
 from transformers.models.llama.modeling_llama import LlamaAttention
 from transformers.utils.import_utils import _is_package_available
+from dataclasses import dataclass, field
 import pytest  # pylint: disable=import-error
 import torch
+from typing import Dict
 
 BNB = "bitsandbytes"
 GPTQ = "auto_gptq"
@@ -237,22 +239,19 @@ def loaded_models(device: torch.device = "cuda"):
         ),
     }
 
+    @dataclass
     class TrainArgs:
-        gradient_checkpointing = False
-        gradient_checkpointing_kwargs = {}
-        fp16 = False
-        bf16 = False
-
-        def __init__(self, **kwargs):
-            for k, v in kwargs.items():
-                setattr(self, k, v)
+        gradient_checkpointing: bool = False
+        gradient_checkpointing_kwargs: Dict = field(default_factory=dict)
+        fp16: bool = False
+        bf16: bool = False
 
     all_models = {}
     for dtype in DTYPES:
         for base_type in [BNB, GPTQ]:
 
             args = TrainArgs(
-                fp16=dtype==FLOAT16
+                fp16=(dtype==FLOAT16)
             )
 
             for r, lora_alpha in LORA_PARAMS:

--- a/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
+++ b/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
@@ -382,6 +382,12 @@ def test_adapter_gradients_match_with_attention_layer(
                     attn = attention_layers[(base_type, r, lora_alpha, dtype)]
                     DummyDropout.dropout_mask = dropout_masks[(sl, hd, d)]
 
+                    # because we want to check the input gradients, we need to have
+                    # the lora_B be initialized to non-zero
+                    for name, param in attn.named_parameters():
+                        if 'lora_B' in name:
+                            torch.nn.init.normal_(param)
+
                     X_without = X.clone().detach().requires_grad_()
                     X_with = X.clone().detach().requires_grad_()
 
@@ -406,6 +412,7 @@ def test_adapter_gradients_match_with_attention_layer(
                         assert (
                             loss_unpatched - loss_patched
                         ).abs() < LOSS_TOL, "Loss after foak patch do not match"
+                        import pdb; pdb.set_trace() 
 
                         # check input gradients
                         torch.allclose(

--- a/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
+++ b/plugins/fused-ops-and-kernels/tests/test_fused_ops.py
@@ -412,7 +412,6 @@ def test_adapter_gradients_match_with_attention_layer(
                         assert (
                             loss_unpatched - loss_patched
                         ).abs() < LOSS_TOL, "Loss after foak patch do not match"
-                        import pdb; pdb.set_trace() 
 
                         # check input gradients
                         torch.allclose(


### PR DESCRIPTION
This PR fixes #97. 
- update `bnb` and `auto_gptq` fused-lora to correctly account for dropout in the backward.
- fix tests to correct patch model, and compute and test input gradients for `test_adapter_gradients_match_with_attention_layer`
- unfortunately we cannot test `input_grads` for GPTQ in `test_adapter_gradients_match_with_attention_layer`, this is a limitation of unable to properly load a small GPTQ model.

~In addition we also disable the MLP fused op for certain models, and removed the old `fast_quantized_peft` plugin.~ We defer this to another PR

### Regerssions

Looks quite good. The node I got is a little slower, but everything seems to be inline.

![image](https://github.com/user-attachments/assets/2f5d3bec-1333-4682-b151-bf17bba85b7b) | ![image](https://github.com/user-attachments/assets/0adcc55d-a396-4e8b-bfba-6e65113cc4cf)
--|--
![image](https://github.com/user-attachments/assets/d60e0b37-804c-4111-af26-345062326630) | ![image](https://github.com/user-attachments/assets/8f03a8e5-8333-48bb-850b-12e9b200efd2)
[benchmarks.csv](https://github.com/user-attachments/files/17671833/benchmarks.csv)

