### PR TITLE
fix: requirements file path in error

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
@@ -35,7 +35,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "kernel-hyperdrive PyPI package not found. Install it: "
-        "pip install -r plugins/accelerated-moe/requirements-scattermoe.txt"
+        "pip install -r plugins/accelerated-moe/requirements-khd.txt"
     ) from e
 
 # Local


### PR DESCRIPTION
Small fix, import error file is [requirements-khd.txt](https://github.com/foundation-model-stack/fms-acceleration/blob/main/plugins/accelerated-moe/requirements-khd.txt), but error points to requirements-scattermoe.txt