### PR TITLE
Decouple Filter MP Rules function from cuda imports

### DIFF
--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/framework_plugin_fast_kernels.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/framework_plugin_fast_kernels.py
@@ -23,8 +23,7 @@ from transformers import PretrainedConfig, TrainingArguments
 import torch
 
 # Local
-from .models.utils import filter_mp_rules
-from .utils import lora_adapters_switch_ddp_from_fsdp
+from .utils import filter_mp_rules, lora_adapters_switch_ddp_from_fsdp
 
 
 # consider rewriting register_foak_model_patch_rules into something

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/granite.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/granite.py
@@ -30,12 +30,12 @@ from ..fused_ops.liger_ce.fused_linear_cross_entropy_loss import lce_forward
 from ..kernels.unsloth.cross_entropy_loss import FastCrossEntropyLoss
 from ..kernels.unsloth.rms_layernorm import fast_rms_layernorm
 from ..kernels.unsloth.rope_embedding import fast_rope_embedding
+from ..utils import filter_mp_rules
 from .utils import (
     KEY_MLP,
     KEY_O,
     KEY_QKV,
     build_lora_fused_ops,
-    filter_mp_rules,
     get_hidden_activation_fn_key,
     trigger_fused_ops,
 )

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/llama.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/llama.py
@@ -36,12 +36,12 @@ from ..fused_ops.liger_ce.fused_linear_cross_entropy_loss import lce_forward
 from ..kernels.unsloth.cross_entropy_loss import FastCrossEntropyLoss
 from ..kernels.unsloth.rms_layernorm import fast_rms_layernorm
 from ..kernels.unsloth.rope_embedding import fast_rope_embedding
+from ..utils import filter_mp_rules
 from .utils import (
     KEY_MLP,
     KEY_O,
     KEY_QKV,
     build_lora_fused_ops,
-    filter_mp_rules,
     get_hidden_activation_fn_key,
     trigger_fused_ops,
 )

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/mistral.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/mistral.py
@@ -36,12 +36,12 @@ from ..fused_ops.liger_ce.fused_linear_cross_entropy_loss import lce_forward
 from ..kernels.unsloth.cross_entropy_loss import FastCrossEntropyLoss
 from ..kernels.unsloth.rms_layernorm import fast_rms_layernorm
 from ..kernels.unsloth.rope_embedding import fast_rope_embedding
+from ..utils import filter_mp_rules
 from .utils import (
     KEY_MLP,
     KEY_O,
     KEY_QKV,
     build_lora_fused_ops,
-    filter_mp_rules,
     get_hidden_activation_fn_key,
     trigger_fused_ops,
 )

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/utils.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/models/utils.py
@@ -1,10 +1,10 @@
 # Standard
 from functools import partial
-from typing import Callable, List, Set, Type
+from typing import Callable, List, Type
 import os
 
 # Third Party
-from fms_acceleration.model_patcher import ModelPatcherRule, ModelPatcherTrigger
+from fms_acceleration.model_patcher import ModelPatcherTrigger
 from transformers import PretrainedConfig
 import torch
 
@@ -201,22 +201,6 @@ def trigger_fused_ops(
     # are all loralayers
     _mods = [getattr(module, x) for x in submodule_names]
     return isinstance(module, attn_cls) and all(_is_loralayer(x) for x in _mods)
-
-
-# helper function to filter rules
-def filter_mp_rules(
-    rules: List[ModelPatcherRule],
-    filter_endswith: Set[str],
-    drop: bool = False,
-):
-    if drop:
-        # this means if any of the filter terms appear, we drop
-        return [
-            r for r in rules if not any(r.rule_id.endswith(x) for x in filter_endswith)
-        ]
-
-    # this means if any if the filter terms appear, we keep
-    return [r for r in rules if any(r.rule_id.endswith(x) for x in filter_endswith)]
 
 
 # helper function to get the hidden activation function str

--- a/plugins/fused-ops-and-kernels/tests/test_model_utils.py
+++ b/plugins/fused-ops-and-kernels/tests/test_model_utils.py
@@ -2,7 +2,7 @@
 from fms_acceleration.model_patcher import ModelPatcherRule
 
 # First Party
-from fms_acceleration_foak.models.utils import filter_mp_rules
+from fms_acceleration_foak.utils import filter_mp_rules
 
 
 def test_filter_mp_rules():


### PR DESCRIPTION
Unwittingly due to the recent PR #106 we had introduced a `filter_mp_rules` function and placed it into `models.utils`. Unfortunately, that file does cuda kernel imports, and will cause `pip install ` failures in machines with no GPU. This is is critical because it precludes building images in CI machines that typically do not have GPUs.

<details>
<summary> Failure </summary>
#33 15.79   File "/usr/lib64/python3.11/ctypes/__init__.py", line 394, in __getitem__
#33 15.79     func = self._FuncPtr((name_or_ordinal, self))
#33 15.79            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#33 15.79 AttributeError: /home/tuning/.local/lib/python3.11/site-packages/bitsandbytes/libbitsandbytes_cpu.so: undefined symbol: cdequantize_blockwise_fp32
..#33 ERROR: process "/bin/sh -c if [[ \"${ENABLE_FMS_ACCELERATION}\" == \"true\" ]]; then         python -m pip install --user \"$(head bdist_name)[fms-accel]\";         python -m fms_acceleration.cli install fms_acceleration_peft;         python -m fms_acceleration.cli install fms_acceleration_foak;         python -m fms_acceleration.cli install fms_acceleration_aadp;     fi" did not complete successfully: exit code: 1
------
 > importing cache manifest from docker-na-private.artifactory.swg-devops.com/wcp-ai-foundation-team-docker-virtual/sft-trainer-aim:release_ubi9_py311:
------
------
 > importing cache manifest from sft-trainer-aim:release_ubi9_py311:
------
------
</details>

To fix this we move `filter_mp_rules` out in a different function. We seem to observe that this will [solve the problem](https://github.com/foundation-model-stack/fms-hf-tuning/actions/runs/12600475365/job/35119582282?pr=433) 