### PR TITLE
feat: move model loader functionality to augmentation

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -17,8 +17,8 @@ from typing import Dict, Tuple
 
 # Third Party
 from fms_acceleration import AccelerationPlugin
-from transformers import TrainingArguments
 from peft import LoraConfig
+from transformers import TrainingArguments
 import torch
 
 # Local
@@ -78,7 +78,6 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
             mixed_precision=False,  # Currently this is hardcoded to OFF
         )
         return model, modifiable_args
-
 
     def get_callbacks_and_ready_for_train(
         self, model: torch.nn.Module = None, accelerator=None

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -67,6 +67,11 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
             world_size = torch.distributed.get_world_size()
             rank = torch.distributed.get_rank()
 
+        if not hasattr(model.config, "name_or_path") or not model.config.name_or_path:
+            raise ValueError(
+                "The model configuration is missing the 'name_or_path' attribute."
+            )
+
         model_name = model.config.name_or_path
 
         self._moe_component_module_names = prepare_scattermoe(

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -17,7 +17,7 @@ from typing import Dict, Tuple
 
 # Third Party
 from fms_acceleration import AccelerationPlugin
-from transformers import AutoModelForCausalLM, TrainingArguments
+from transformers import TrainingArguments
 from peft import LoraConfig
 import torch
 

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -53,7 +53,7 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
         )
 
     @property
-    def requires_agumentation(self):
+    def requires_augmentation(self):
         return True
 
     def augmentation(

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 # Standard
-from typing import Dict
+from typing import Dict, Tuple
 
 # Third Party
 from fms_acceleration import AccelerationPlugin
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, TrainingArguments
+from peft import LoraConfig
 import torch
 
 # Local
@@ -55,33 +56,83 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
     def requires_custom_loading(self):
         return True
 
-    def model_loader(self, model_name: str, **kwargs):
+    # def model_loader(self, model_name: str, **kwargs):
 
-        # load the model
-        model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
+    #     # load the model
+    #     model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
 
-        rank, world_size = 0, 1
-        if torch.distributed.is_initialized():
-            world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+    #     rank, world_size = 0, 1
+    #     if torch.distributed.is_initialized():
+    #         world_size = torch.distributed.get_world_size()
+    #         rank = torch.distributed.get_rank()
 
-        # shard the MOE, and store the component names, eventually needed
-        # to configure the FSDP
-        self._moe_component_module_names = prepare_scattermoe(
-            model,
-            checkpoint_name_or_path=model_name,
-            rank=rank,
-            world_size=world_size,
-            ep_degree=self._ep_degree,
-            mixed_precision=False,  # Currently this is hardcoded to OFF
+    #     # shard the MOE, and store the component names, eventually needed
+    #     # to configure the FSDP
+    #     self._moe_component_module_names = prepare_scattermoe(
+    #         model,
+    #         checkpoint_name_or_path=model_name,
+    #         rank=rank,
+    #         world_size=world_size,
+    #         ep_degree=self._ep_degree,
+    #         mixed_precision=False,  # Currently this is hardcoded to OFF
+    #     )
+
+    #     # NOTE: there is currently no good way to get the mixed precision
+    #     # flag from train_args. It will be better to handle this if
+    #     # when we move the sharding to augmentation.
+    #     # https://github.com/foundation-model-stack/fms-acceleration/issues/103
+
+    #     return model
+    def augmentation(
+        self,
+        model,
+        train_args: TrainingArguments,
+        modifiable_args: Tuple[LoraConfig],
+    ):
+        # guarded because multipack has numba dependencies
+        # Third Party
+        # pylint: disable=import-outside-toplevel
+        from fms_acceleration.accelerator_patcher import (
+            AcceleratorPatcher,
+            AcceleratorPatcherComponent,
         )
 
-        # NOTE: there is currently no good way to get the mixed precision
-        # flag from train_args. It will be better to handle this if
-        # when we move the sharding to augmentation.
-        # https://github.com/foundation-model-stack/fms-acceleration/issues/103
+        # Local
+        from .aadp_utils import (  # pylint: disable=import-outside-toplevel
+            calculate_token_lengths,
+        )
+        from .multipack_sampler import (  # pylint: disable=import-outside-toplevel
+            MultipackDistributedBatchSampler,
+        )
 
-        return model
+        rank, num_bins = 0, 1
+        if torch.distributed.is_initialized():
+            num_bins = torch.distributed.get_world_size()
+            rank = torch.distributed.get_rank()
+        else:
+            # NOTE: or should we do a silent fallback
+            raise AssertionError(
+                "Multipack dataloader only works for distributed training."
+            )
+
+        # some checks
+        def _prereq(dataloader: DataLoader):
+            return hasattr(dataloader, "dataset")
+        
+        def 
+
+        AcceleratorPatcher.replace(
+            "scattermoe",
+            AcceleratorPatcherComponent.data_loader,
+            replacement_builder=_build_scattermoe_dataloader,
+            pre_requisite_check=_prereq,
+            skip_prepare=True,
+        )
+
+        # take a pointer to train args
+        self._train_args = train_args
+        return model, modifiable_args
+
 
     def get_callbacks_and_ready_for_train(
         self, model: torch.nn.Module = None, accelerator=None


### PR DESCRIPTION
**Description**
Step 1 of 3 for enabling LoRA on ScatterMoE: move model loader functionality to augmentation. This makes it so the plugin doesn't have to be standalone as well. 


**Testing**
Testing on fms-hf-tuning with augmentation function instead of model loader shows similar results to [#390](https://github.com/foundation-model-stack/fms-hf-tuning/pull/390):
```
      {
          "model_name_or_path": "/ibm_dmf_lakehouse/models/base_training/shared/granite-3.0-3b-a800m-base/r240924a",
          "training_data_path": "/testing/tuning/input/cc_tone_sft_format_1000_train.json",
          "output_dir": "/testing/tuning/output/granite-3b-moe/ft/20240107_1014-tone-FAST",
          "save_model_dir": "/testing/tuning/output/granite-3b-moe/ft/20240107_1014-tone-FAST/save_model",
          "num_train_epochs": 10.0,
          "per_device_train_batch_size": 2,
          "gradient_accumulation_steps": 1,
          "learning_rate": 1e-5,
          "response_template": "\n### Response:",
          "dataset_text_field": "output",
          "fast_moe": 1
      }
```
Results:
```
{'loss': 0.834, 'grad_norm': 326.0, 'learning_rate': 9e-06, 'epoch': 1.0}
{'loss': 0.4279, 'grad_norm': 0.076171875, 'learning_rate': 8.000000000000001e-06, 'epoch': 2.0}
{'loss': 0.1377, 'grad_norm': 3.78125, 'learning_rate': 7e-06, 'epoch': 3.0}
{'loss': 0.0384, 'grad_norm': 0.81640625, 'learning_rate': 6e-06, 'epoch': 4.0}
{'loss': 0.0031, 'grad_norm': 0.003997802734375, 'learning_rate': 5e-06, 'epoch': 5.0}
{'loss': 0.0006, 'grad_norm': 0.002044677734375, 'learning_rate': 4.000000000000001e-06, 'epoch': 6.0}
{'loss': 0.0002, 'grad_norm': 0.0032196044921875, 'learning_rate': 3e-06, 'epoch': 7.0}
{'loss': 0.0001, 'grad_norm': 0.002288818359375, 'learning_rate': 2.0000000000000003e-06, 'epoch': 8.0}
{'loss': 0.0001, 'grad_norm': 0.0087890625, 'learning_rate': 1.0000000000000002e-06, 'epoch': 9.0}
{'loss': 0.0001, 'grad_norm': 0.0115966796875, 'learning_rate': 0.0, 'epoch': 10.0}
{'train_runtime': 2125.7018, 'train_samples_per_second': 4.704, 'train_steps_per_second': 2.352, 'train_loss': 0.14420232288464904, 'epoch': 10.0}                                                                                           
```
model location: `/testing/tuning/output/granite-3b-moe/ft/20240107_1014-tone/save_model`