### PR TITLE
fix: Allow for multi node training for accelerated moe

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -69,7 +69,8 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
         rank, world_size = 0, 1
         if torch.distributed.is_initialized():
             world_size = torch.distributed.get_world_size()
-            rank = torch.distributed.get_rank()
+            # we do not need to use the fallback as this is wrapped in an `is_initialized` block
+            rank = torch.distributed.get_node_local_rank()
 
         if not hasattr(model.config, "name_or_path") or not model.config.name_or_path:
             raise ValueError(


### PR DESCRIPTION
Current implementation uses global rank of the process to prepare the device index which would not work in a multi node setting. Therefore, we would need to use local rank since devices are not continuously indexed across the nodes.