### PR TITLE
chore: Move dcp to safetensors to a wrapper function for downstream usage

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/__init__.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/__init__.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 # Local
-from .checkpoint_utils import patch_huggingface_save_and_load_for_dtensors
+from .checkpoint_utils import (
+    patch_huggingface_save_and_load_for_dtensors,
+    recover_safetensors_from_dcp,
+)
 from .scattermoe_prepare import prepare_scattermoe
 
 # this is a special patch function to disable foreach for


### PR DESCRIPTION
Add a wrapper function to wrap complete dcp to safetensor logic in order to enable easy downstream usage through this function without needing to redundantly repeat the same set of steps.