### PR TITLE
fix: Using PaddingFree plugin with Iterable datasets and remove_columns

### DIFF
--- a/plugins/attention-and-distributed-packing/src/fms_acceleration_aadp/framework_plugin_padding_free.py
+++ b/plugins/attention-and-distributed-packing/src/fms_acceleration_aadp/framework_plugin_padding_free.py
@@ -20,6 +20,7 @@ import warnings
 from fms_acceleration import AccelerationPlugin
 from peft import LoraConfig
 from transformers import DataCollatorForSeq2Seq, TrainingArguments
+from transformers.trainer_utils import RemoveColumnsCollator
 from trl import DataCollatorForCompletionOnlyLM  # pylint: disable=import-error
 import torch
 
@@ -71,7 +72,7 @@ class PaddingFreeAccelerationPlugin(AccelerationPlugin):
             # `DataCollatorForSeq2Seq` collate_fn,
             # otherwise the collation can be unreliable"
             return isinstance(
-                collate_fn, (DataCollatorForSeq2Seq, DataCollatorForCompletionOnlyLM)
+                collate_fn, (DataCollatorForSeq2Seq, DataCollatorForCompletionOnlyLM, RemoveColumnsCollator)
             )
 
         # This check is done here to only patch the attention forward
@@ -96,6 +97,14 @@ class PaddingFreeAccelerationPlugin(AccelerationPlugin):
             from .aadp_utils import DataCollatorWithFlattening
 
         def _collator_replacement_builder(collate_fn):
+
+            # in case of remove columns collator the actual collate
+            # function is wrapped inside
+            if isinstance(collate_fn, RemoveColumnsCollator):
+                actual_collate_fn = collate_fn.data_collator
+                replacement = _collator_replacement_builder(actual_collate_fn)
+                collate_fn.data_collator = replacement
+                return collate_fn
 
             # in this case, replace seq2seq with flattening collator
             if isinstance(collate_fn, DataCollatorForSeq2Seq):


### PR DESCRIPTION
While doing our testing of using Iterable Datasets in few training runs we hit this error where the collator being used at training time was [RemoveColumnsCollator](https://github.com/huggingface/transformers/blob/main/src/transformers/trainer_utils.py#L833). It seems that at times trl internally wraps the collator we pass either `DataCollatorForSeq2Seq` or `DataCollatorForCompletionOnlyLM` inside this `RemoveColumnsCollator` to remove columns at batch creation time. 

The simple fix for making this collator work with the padding free plugin is to unwrap the actual collator and try to build a replacement for the same.