### PR TITLE
feat: lora for accelerated MoE v1 - router only

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -59,6 +59,7 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
         modifiable_args: Tuple[LoraConfig],
     ):
         rank, world_size = 0, 1
+        (peft_config,) = modifiable_args
         if torch.distributed.is_initialized():
             world_size = torch.distributed.get_world_size()
             # we do not need to use the fallback as this is wrapped in an `is_initialized` block
@@ -78,6 +79,7 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
             world_size=world_size,
             ep_degree=self._ep_degree,
             mixed_precision=False,  # Currently this is hardcoded to OFF
+            lora_config=peft_config
         )
         return model, modifiable_args
 

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/framework_plugin_scattermoe.py
@@ -79,7 +79,7 @@ class ScatterMoEAccelerationPlugin(AccelerationPlugin):
             world_size=world_size,
             ep_degree=self._ep_degree,
             mixed_precision=False,  # Currently this is hardcoded to OFF
-            lora_config=peft_config
+            lora_config=peft_config,
         )
         return model, modifiable_args
 

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -344,7 +344,7 @@ def recover_original_state_dict_from_checkpoint(
     ):
         _name = "|".join([PARAM_NAME_ROUTER_SCATTERMOE, *PARAM_NAME_WEIGHT_SCATTERMOE])
         # pylint: disable=anomalous-backslash-in-string
-        _reg = re.compile(f"(.*)\.({_name})\.weight")
+        _reg = re.compile(rf"(.*)\.({_name})\.(?:weight|lora_A\.weight|lora_B\.weight)")
         found = {}
 
         for k in sd_keys:

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -340,7 +340,7 @@ def recover_original_state_dict_from_checkpoint(
 
     def _infer_prefixes_and_module_names(
         sd_keys: List[str],
-        min_count: int = 3,
+        min_count: int = 1,
     ):
         _name = "|".join([PARAM_NAME_ROUTER_SCATTERMOE, *PARAM_NAME_WEIGHT_SCATTERMOE])
         # pylint: disable=anomalous-backslash-in-string
@@ -398,6 +398,7 @@ def recover_original_state_dict_from_checkpoint(
         #   model param and they need to be cat
         for scatter_key, list_of_params in checkpoint_metadata.items():
             scatter_key_fqdn = ".".join([prefix, module_name, scatter_key])
+            
             scatter_param = sd[scatter_key_fqdn]
 
             # remove from state dict

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -340,7 +340,7 @@ def recover_original_state_dict_from_checkpoint(
 
     def _infer_prefixes_and_module_names(
         sd_keys: List[str],
-        min_count: int = 1,
+        min_count: int = 3,
     ):
         _name = "|".join([PARAM_NAME_ROUTER_SCATTERMOE, *PARAM_NAME_WEIGHT_SCATTERMOE])
         # pylint: disable=anomalous-backslash-in-string

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -412,6 +412,7 @@ def recover_original_state_dict_from_checkpoint(
             module_name,
             router_name,
             expert_name,
+            lora_utils=lora,
         )
 
         model2scatter = defaultdict(dict)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -344,7 +344,7 @@ def recover_original_state_dict_from_checkpoint(
     ):
         _name = "|".join([PARAM_NAME_ROUTER_SCATTERMOE, *PARAM_NAME_WEIGHT_SCATTERMOE])
         # pylint: disable=anomalous-backslash-in-string
-        _reg = re.compile(rf"(.*)\.({_name})\.(?:weight|lora_A\.weight|lora_B\.weight)")
+        _reg = re.compile(rf"(.*)\.({_name})\.(?:weight|lora_A|lora_B)")
         found = {}
 
         for k in sd_keys:

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -610,7 +610,7 @@ def recover_safetensors_from_dcp(
         new_state_dict[name] = param
 
     # recover the original state dict
-    state_dict = recover_original_state_dict_from_checkpoint(state_dict, lora, _name_or_path)
+    state_dict = recover_original_state_dict_from_checkpoint(new_state_dict, lora, _name_or_path)
 
     # save it as a safetensors file
     save_sharded_safetensors(

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -461,6 +461,20 @@ def recover_original_state_dict_from_checkpoint(
 
             if len(scatter_keys) == 1:
                 sd[model_key] = scatter_params[scatter_keys[0]]
+
+            elif any("lora_A" in k for k in scatter_keys) and any("lora_B" in k for k in scatter_keys):
+                lora_A_key = next((k for k in scatter_keys if "lora_A" in k), None)
+                lora_B_key = next((k for k in scatter_keys if "lora_B" in k), None)
+
+                if lora_A_key and lora_B_key:
+                    lora_A = scatter_params[lora_A_key]
+                    lora_B = scatter_params[lora_B_key]
+
+                    # Multiply matrices
+                    lora_weight = torch.matmul(lora_B, lora_A)
+
+                    sd[model_key] = lora_weight
+
             else:
                 # unfortunately, there this is a in
                 # scattermoe_state_dict._maybe_reshape_scattermoe_expert_weights

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -483,7 +483,7 @@ def recover_original_state_dict_from_checkpoint(
 
                     # Replace the component after 'block_sparse_moe' in lora_key
                     updated_lora_parts = lora_parts[:]
-                    updated_lora_parts[lora_index + 1] = model_parts[model_index + 1]
+                    updated_lora_parts[lora_index + 1] = model_parts[model_index + 1] + ".layer"
 
                     # Return the updated lora parts as the model key
                     return ".".join(updated_lora_parts)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -386,7 +386,7 @@ def recover_original_state_dict_from_checkpoint(
 
         return results
 
-    for prefix in _infer_prefixes_and_module_names(sd.keys()):
+    for prefix in _infer_prefixes_and_module_names(sd.keys(), lora):
         prefix = prefix.split(".")
         prefix, module_name = ".".join(prefix[:-1]), prefix[-1]
 

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -466,11 +466,7 @@ def recover_original_state_dict_from_checkpoint(
             ), f"Obtained zero scatter keys for model_key '{model_key}'"
 
             if any("lora_A" in k for k in scatter_keys) and any("lora_B" in k for k in scatter_keys):
-                # If lora, do not associate to model keys but keep scatter keys
-                # TODO: Actually these need to be associated with an
-                # input-linear and output-linear layer much like the FT case
-                # so, do that. Seperate the cases out. Use torch.cat if len
-                # scatter keys is greater than 2
+                # If lora, split input linear and output linear into lora layers
                 def transform_model_key(model_key, lora_key):
                     lora_parts = lora_key.split(".")
                     model_parts = model_key.split(".")

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
@@ -278,28 +278,10 @@ class ScatterMoE(torch.nn.Module):
         # - w1: the up_projection.
         # - w2: the down_projection.
         # - w3 (optional): the gate projection.
-        self.w1 = ScatteredExperts(
-            in_features=self.hidden_size,
-            out_features=self.intermediate_size,
-            num_experts=self.num_experts,
-            fan_out=self.top_k if not self.all_to_all else 1,
-            grouped_out=True,
-            dtype=dtype,
-            device=device,
-            lora_config=lora_config,
-        )
-        self.w2 = ScatteredExperts(
-            in_features=self.intermediate_size,
-            out_features=self.hidden_size,
-            num_experts=self.num_experts,
-            fan_out=1,
-            grouped_in=True,
-            dtype=dtype,
-            device=device,
-            lora_config=lora_config,
-        )
-        if mlp_arch == SCATTERMOE_SPEC_HAS_GATE:
-            self.w3 = ScatteredExperts(
+        # TODO: Custom non-linear layers not supported in vLLM,
+        # must be investigated further before enabling
+        if lora_config is not None:
+            self.w1 = ScatteredExperts(
                 in_features=self.hidden_size,
                 out_features=self.intermediate_size,
                 num_experts=self.num_experts,
@@ -309,6 +291,27 @@ class ScatterMoE(torch.nn.Module):
                 device=device,
                 lora_config=lora_config,
             )
+            self.w2 = ScatteredExperts(
+                in_features=self.intermediate_size,
+                out_features=self.hidden_size,
+                num_experts=self.num_experts,
+                fan_out=1,
+                grouped_in=True,
+                dtype=dtype,
+                device=device,
+                lora_config=lora_config,
+            )
+            if mlp_arch == SCATTERMOE_SPEC_HAS_GATE:
+                self.w3 = ScatteredExperts(
+                    in_features=self.hidden_size,
+                    out_features=self.intermediate_size,
+                    num_experts=self.num_experts,
+                    fan_out=self.top_k if not self.all_to_all else 1,
+                    grouped_out=True,
+                    dtype=dtype,
+                    device=device,
+                    lora_config=lora_config,
+                )
 
     # referenced from dolomite-engine
     def _compute_routing_weights(self, hidden_states: torch.Tensor):

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
@@ -460,14 +460,15 @@ class ScatterMoE(torch.nn.Module):
             )
 
         # compute the up projection
-        out = self.w1(
-            hidden_states,
-            sorted_expert_idxs,
-            sorted_scattered_idxs,
-            padded_block_idxs,
-            expert_offsets,
-        )
-        out = self.activation(out)
+        if self.w1:
+            out = self.w1(
+                hidden_states,
+                sorted_expert_idxs,
+                sorted_scattered_idxs,
+                padded_block_idxs,
+                expert_offsets,
+            )
+            out = self.activation(out)
 
         # - if the arch has a seperate gate projection
         if self.w3:
@@ -482,21 +483,22 @@ class ScatterMoE(torch.nn.Module):
         # compute the down projection
         # - if no all-to-all processing, then depend on
         # scattermoe kernel to perform the final scattering
-        hidden_states = self.w2(
-            out,
-            sorted_expert_idxs,
-            sorted_scattered_idxs,
-            padded_block_idxs,
-            expert_offsets,
-            gates=(None if self.all_to_all else routing_weights),
-        )
+        if self.w2:
+            hidden_states = self.w2(
+                out,
+                sorted_expert_idxs,
+                sorted_scattered_idxs,
+                padded_block_idxs,
+                expert_offsets,
+                gates=(None if self.all_to_all else routing_weights),
+            )
 
-        # maybe scatter
-        hidden_states = self._maybe_scatter(
-            hidden_states,
-            routing_weights,
-            _gather_products,
-        )
+            # maybe scatter
+            hidden_states = self._maybe_scatter(
+                hidden_states,
+                routing_weights,
+                _gather_products,
+            )
 
         # return hidden states and router logits
         return (hidden_states.view(original_shape), router_logits)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe.py
@@ -280,7 +280,7 @@ class ScatterMoE(torch.nn.Module):
         # - w3 (optional): the gate projection.
         # TODO: Custom non-linear layers not supported in vLLM,
         # must be investigated further before enabling
-        if lora_config is not None:
+        if lora_config is None:
             self.w1 = ScatteredExperts(
                 in_features=self.hidden_size,
                 out_features=self.intermediate_size,

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_constants.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_constants.py
@@ -24,7 +24,9 @@ KEY_REPLICATE = "replicate"
 KEY_EXPERT_PARALLEL = "expert_parallel"
 DIM_EXPERT = 0
 
-KEY_SCATTERMOE_ROUTER = PARAM_NAME_ROUTER_SCATTERMOE + ".weight"
+KEY_SCATTERMOE_ROUTER = "router.weight"
+KEY_SCATTERMOE_LORA_A_ROUTER = "router.lora_A.weight"
+KEY_SCATTERMOE_LORA_B_ROUTER = "router.lora_B.weight"
 
 # Currently out ScatterMoE drop supports an up/down proj, and
 # and optional gate_proj.

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -247,6 +247,7 @@ def prepare_scattermoe(
                 weight_map,
                 prefix,
                 module_name,
+                lora,
                 router_name,
                 "|".join(expert_name),
             )

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -82,22 +82,21 @@ def load_experts_onto_device(
                 param, device_mesh=device_mesh, placements=reps + [Shard(0)]
             )
 
-        if not lora:
-            # get the module we want to shard
-            name = weight_name.split(".")
-            path, name = ".".join(name[:-1]), name[-1]
-            mod = module.get_submodule(path)
-            requires_grad = getattr(mod, name).requires_grad
+        # get the module we want to shard
+        name = weight_name.split(".")
+        path, name = ".".join(name[:-1]), name[-1]
+        mod = module.get_submodule(path)
+        requires_grad = getattr(mod, name).requires_grad
 
-            param = torch.nn.Parameter(
-                param,
-                requires_grad=requires_grad,
-            )
+        param = torch.nn.Parameter(
+            param,
+            requires_grad=requires_grad,
+        )
 
-            # install gradient scaling hook
-            if KEY_SCATTERMOE_ROUTER not in weight_name:
-                if param.requires_grad:
-                    param.register_hook(_hook) 
+        # install gradient scaling hook
+        if KEY_SCATTERMOE_ROUTER not in weight_name:
+            if param.requires_grad:
+                param.register_hook(_hook) 
 
         # register the sharded parameter onto the megablocks.dmoe
         mod.register_parameter(name, param)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -93,8 +93,9 @@ def load_experts_onto_device(
         )
 
         # install gradient scaling hook
-        if KEY_SCATTERMOE_ROUTER not in weight_name: # does this need to look for lora a and b as well?
-            param.register_hook(_hook) 
+        if KEY_SCATTERMOE_ROUTER not in weight_name and KEY_SCATTERMOE_LORA_A_ROUTER not in weight_name and KEY_SCATTERMOE_LORA_B_ROUTER not in weight_name:
+            if param.requires_grad:
+                param.register_hook(_hook) 
 
         # register the sharded parameter onto the megablocks.dmoe
         mod.register_parameter(name, param)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -34,6 +34,8 @@ from .scattermoe_constants import (
     KEY_EXPERT_PARALLEL,
     KEY_REPLICATE,
     KEY_SCATTERMOE_ROUTER,
+    KEY_SCATTERMOE_LORA_A_ROUTER,
+    KEY_SCATTERMOE_LORA_B_ROUTER,
     get_scattermoe_conv_spec_from_archs,
 )
 from .scattermoe_state_dict import (
@@ -66,7 +68,7 @@ def load_experts_onto_device(
 
     for weight_name, param in state_dict.items():
 
-        if KEY_SCATTERMOE_ROUTER in weight_name:
+        if KEY_SCATTERMOE_ROUTER in weight_name or KEY_SCATTERMOE_LORA_A_ROUTER in weight_name or KEY_SCATTERMOE_LORA_B_ROUTER in weight_name:
             # if its the router, replicate
             param = distribute_tensor(param, device_mesh, reps + [Replicate()])
         elif param.shape[0] > num_experts_per_device:

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -93,8 +93,8 @@ def load_experts_onto_device(
         )
 
         # install gradient scaling hook
-        if KEY_SCATTERMOE_ROUTER not in weight_name:
-            param.register_hook(_hook)
+        if KEY_SCATTERMOE_ROUTER not in weight_name: # does this need to look for lora a and b as well?
+            param.register_hook(_hook) 
 
         # register the sharded parameter onto the megablocks.dmoe
         mod.register_parameter(name, param)

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_prepare.py
@@ -246,9 +246,9 @@ def prepare_scattermoe(
                 weight_map,
                 prefix,
                 module_name,
-                lora,
                 router_name,
                 "|".join(expert_name),
+                lora_start=lora
             )
 
             # the parent module

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
@@ -173,8 +173,8 @@ def get_checkpoint_meta_from_sharded_safetensor(
             )
         if m.group(1) == router_name:
             if lora_utils:
-                _map["router.layer.lora_A.default.weight"].append((k, stfile))
-                _map["router.layer.lora_B.default.weight"].append((k, stfile))
+                _map["router.lora_A.default.weight"].append((k, stfile))
+                _map["router.lora_B.default.weight"].append((k, stfile))
             else:
                 _map[KEY_SCATTERMOE_ROUTER].append((k, stfile))
         elif m.group(1) in expert_name:

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
@@ -151,10 +151,6 @@ def get_checkpoint_meta_from_sharded_safetensor(
     # `w1.weight`: [...]
     _map = defaultdict(list)
     prefix = f"{prefix}.{instance_name}."
-    # Lora case in checkpoint_utils where it prefix looks like 
-    # `base_model.model.model...` instead of `model...`
-    if not prefix.startswith("model."):
-        prefix=prefix.replace("base_model.model.", "", 1)
 
     for k, stfile in weight_map.items():
         if not k.startswith(prefix):

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
@@ -174,8 +174,8 @@ def get_checkpoint_meta_from_sharded_safetensor(
             )
         if m.group(1) == router_name:
             if lora:
-                _map["router.lora_A.default.weight"].append((k, stfile))
-                _map["router.lora_B.default.weight"].append((k, stfile))
+                _map["router.layer.lora_A.default.weight"].append((k, stfile))
+                _map["router.layer.lora_B.default.weight"].append((k, stfile))
             else:
                 _map[KEY_SCATTERMOE_ROUTER].append((k, stfile))
         elif m.group(1) in expert_name:

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
@@ -27,6 +27,8 @@ import torch
 from .scattermoe_constants import (
     DIM_EXPERT,
     KEY_SCATTERMOE_ROUTER,
+    KEY_SCATTERMOE_LORA_A_ROUTER,
+    KEY_SCATTERMOE_LORA_B_ROUTER,
     PARAM_NAME_WEIGHT_SCATTERMOE,
 )
 
@@ -295,7 +297,7 @@ def get_state_dict_from_checkpoint_metadata(
         # go by one weight at a time.
         for scatter_key, vs in checkpoint_metadata.items():
 
-            if KEY_SCATTERMOE_ROUTER in scatter_key:
+            if KEY_SCATTERMOE_ROUTER in scatter_key or KEY_SCATTERMOE_LORA_A_ROUTER in scatter_key or KEY_SCATTERMOE_LORA_B_ROUTER in scatter_key:
                 k, fi = vs[0]  # only one item
                 param = files[fi].get_tensor(k)
 

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/scattermoe_state_dict.py
@@ -173,8 +173,8 @@ def get_checkpoint_meta_from_sharded_safetensor(
             )
         if m.group(1) == router_name:
             if lora_utils:
-                _map["router.lora_A.default.weight"].append((k, stfile))
-                _map["router.lora_B.default.weight"].append((k, stfile))
+                _map[KEY_SCATTERMOE_LORA_A_ROUTER].append((k, stfile))
+                _map[KEY_SCATTERMOE_LORA_B_ROUTER].append((k, stfile))
             else:
                 _map[KEY_SCATTERMOE_ROUTER].append((k, stfile))
         elif m.group(1) in expert_name:


### PR DESCRIPTION
Building on #138 to add peft configs to fast moe augmentation so lora config is passed into `prepare_scattermoe`. Updating checkpoint utility functions to handle lora state dict.
Restrictions:

- lora_config.r must be >= 16
- Must be using FSDP, since the scatteredExperts weights are not supported by peft's LoRA tuning, the overwritten FSDP save and load functions must be utilized here.
- Loading from a default lora adapter config may not work here, intended use-case is to run tuning from base model.
- vLLM inference cannot load custom ScatteredExperts, so lora tuning only tunes the `router.layer`, not `w1`, `w2`, `w3`

Here are logs of the transformation in `checkpoint_utils` before and after the `recover_original_state_dict_from_checkpoint` [function](https://github.com/foundation-model-stack/fms-acceleration/blob/a5bdea2848e269f80e24e200f96e86a1e32caf42/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py#L323):
[scattermoe-router-lora.log](https://github.com/user-attachments/files/19673060/scattermoe-router-lora.log)