### PR TITLE
fix: filter out router so `all-linear` can be tuned for LoRA target modules

### DIFF
--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -113,8 +113,11 @@ def save_fsdp_optimizer(
     (model_state_dict, optimizer_state_dict) = get_state_dict(model, optimizer)
 
     # filter out lora state dict
+    # TODO: Once expert layers are supported for LoRA tuning
+    # remove the "router" filtering
     lora_state_dict = {
-        k: v for k, v in model_state_dict.items() if "lora_A" in k or "lora_B" in k
+        k: v for k, v in model_state_dict.items()
+        if ("lora_A" in k or "lora_B" in k) and "router" not in k
     }
 
     # - save model

--- a/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
+++ b/plugins/accelerated-moe/src/fms_acceleration_moe/utils/checkpoint_utils.py
@@ -116,7 +116,8 @@ def save_fsdp_optimizer(
     # TODO: Once expert layers are supported for LoRA tuning
     # remove the "router" filtering
     lora_state_dict = {
-        k: v for k, v in model_state_dict.items()
+        k: v
+        for k, v in model_state_dict.items()
         if ("lora_A" in k or "lora_B" in k) and "router" not in k
     }
 

--- a/plugins/accelerated-moe/tox.ini
+++ b/plugins/accelerated-moe/tox.ini
@@ -4,6 +4,7 @@ envlist = py, lint
 [testenv]
 deps = 
     pytest>=7
+    importlib-metadata
     -e {toxinidir}
 skip_install = true
 commands = 


### PR DESCRIPTION
Goes with [#545](https://github.com/foundation-model-stack/fms-hf-tuning/pull/545) to allow all-linear for ScatterMoE. This PRs always filters out the `router` in the LoRA state dict, which should be reversed when expert tuning support for LoRA layers is added in, and has been noted as such. This will allow users to pass `all-linear` as target modules when using ScatterMoE