### PR TITLE
fix: update global variable syntax since its not support from triton 3.2.0

### DIFF
--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/cross_entropy_loss.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/cross_entropy_loss.py
@@ -187,7 +187,7 @@ def _cross_entropy_backward(
 pass
 
 
-MAX_FUSED_SIZE: tl.constexpr = 65536 # 2**16
+MAX_FUSED_SIZE = tl.constexpr(65536) # 2**16
 
 class Fast_CrossEntropyLoss(torch.autograd.Function):
     @staticmethod

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/rope_embedding.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/rope_embedding.py
@@ -17,7 +17,7 @@ import triton.language as tl
 import torch
 from .utils import calculate_settings
 
-ROPE_GROUP_SIZE: tl.constexpr = 4
+ROPE_GROUP_SIZE = tl.constexpr(4)
 
 @triton.heuristics({"BACKWARD_PASS": lambda args: args["BACKWARD_PASS"],})
 @triton.jit


### PR DESCRIPTION
triton>3.2.0 does not support annotation based syntax for global variables.

This resulted in errors with our stack such as

```
  File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 83, in make_ir
    return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
triton.compiler.errors.CompilationError: at 33:39:
    sin1 = tl.load(sin + (row_position % seqlen)*sin_row_stride + \
                   half_head_dim*0 + col_offsets, mask = mask, other = 0)
    cos1 = tl.load(cos + (row_position % seqlen)*cos_row_stride + \
                   half_head_dim*0 + col_offsets, mask = mask, other = 0)
    if BACKWARD_PASS:
        # See our blog post for more info.
        sin1 = -sin1
    pass
    # [TODO] Autotune ROPE_GROUP_SIZE to be 1, 2, 4, 8
    head_start = group_head_position * ROPE_GROUP_SIZE
                                       ^
NameError("Cannot access global variable ROPE_GROUP_SIZE from within @jit'ed function. Triton kernels can only access global variables that are instanstiated as constexpr (`x = triton.language.constexpr(42)`). Note that this is different from annotating a variable as constexpr (`x: triton.language.constexpr = 42`), which is not supported.  Alternatively, set the envvar TRITON_ALLOW_NON_CONSTEXPR_GLOBALS=1, but we do not promise to support this forever.")
```

FYA - @HarikrishnanBalagopal @YashasviChaurasia @ashokponkumar 

@fabianlim 