### PR TITLE
fix: update datatype to int

### DIFF
--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/cross_entropy_loss.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/cross_entropy_loss.py
@@ -187,7 +187,7 @@ def _cross_entropy_backward(
 pass
 
 
-MAX_FUSED_SIZE = tl.constexpr(65536) # 2**16
+MAX_FUSED_SIZE = 65536 # 2**16
 
 class Fast_CrossEntropyLoss(torch.autograd.Function):
     @staticmethod

--- a/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/rope_embedding.py
+++ b/plugins/fused-ops-and-kernels/src/fms_acceleration_foak/kernels/unsloth/rope_embedding.py
@@ -17,7 +17,7 @@ import triton.language as tl
 import torch
 from .utils import calculate_settings
 
-ROPE_GROUP_SIZE = tl.constexpr(4)
+ROPE_GROUP_SIZE : int = 4
 
 @triton.heuristics({"BACKWARD_PASS": lambda args: args["BACKWARD_PASS"],})
 @triton.jit
@@ -36,6 +36,7 @@ def _rope_embedding(
         RoPE is Q * cos + rotate_half(Q) * sin
         See our blog post for more info
     """
+    ROPE_GROUP_SIZE = 4
     row_position  = tl.program_id(0)
     group_head_position = tl.program_id(1)
     col_offsets  = tl.arange(0, BLOCK_SIZE)


### PR DESCRIPTION

update datatype to int.
[reference 1](https://github.com/unslothai/unsloth/blob/3808d801a766b67f23bb1727c13da417fcadbdf8/unsloth/kernels/rope_embedding.py#L36)
[reference 2](https://github.com/unslothai/unsloth/blob/3808d801a766b67f23bb1727c13da417fcadbdf8/unsloth/kernels/cross_entropy_loss.py#L290)
Following is screenshot of the run after the fix:
<img width="1567" height="565" alt="image" src="https://github.com/user-attachments/assets/9d0c802f-3281-48b4-a64f-1b8207cea499" />
This fix is extension to #148 